### PR TITLE
Fix TagHandler value parsing and warn of skipped lines.

### DIFF
--- a/src/main/java/com/thebuzzmedia/exiftool/commons/io/IOs.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/commons/io/IOs.java
@@ -20,11 +20,8 @@ package com.thebuzzmedia.exiftool.commons.io;
 import com.thebuzzmedia.exiftool.logs.Logger;
 import com.thebuzzmedia.exiftool.logs.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Static Input/Output Utilities.
@@ -51,7 +48,7 @@ public final class IOs {
 		log.trace("Read input stream");
 
 		String line = null;
-		BufferedReader br = new BufferedReader(new InputStreamReader(is));
+		BufferedReader br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 
 		try {
 			boolean hasNext = true;

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/TagHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/TagHandler.java
@@ -90,7 +90,7 @@ public class TagHandler implements OutputHandler {
 		}
 
 		// Now, we are sure we can process line.
-		String[] pair = TAG_VALUE_PATTERN.split(line, 1);
+		String[] pair = TAG_VALUE_PATTERN.split(line, 2);
 		if (pair != null && pair.length == 2) {
 			// Determine the tag represented by this value.
 			String name = pair[0];

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/TagHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/TagHandler.java
@@ -90,7 +90,7 @@ public class TagHandler implements OutputHandler {
 		}
 
 		// Now, we are sure we can process line.
-		String[] pair = TAG_VALUE_PATTERN.split(line);
+		String[] pair = TAG_VALUE_PATTERN.split(line, 1);
 		if (pair != null && pair.length == 2) {
 			// Determine the tag represented by this value.
 			String name = pair[0];
@@ -109,7 +109,9 @@ public class TagHandler implements OutputHandler {
 			else {
 				log.debug("Unable to read Tag: %s", line);
 			}
-		}
+		} else {
+            log.warn("Skipped line: %s", line);
+        }
 
 		return true;
 	}


### PR DESCRIPTION
Warn when exiftool output lines are skipped, and fix output splitting to only split tag from value and not on all sequences of ": ". Even better might be a pattern like "^\w+: " to split on.