### PR TITLE
Add support for extracting all tags

### DIFF
--- a/src/main/java/com/thebuzzmedia/exiftool/core/UnspecifiedTag.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/UnspecifiedTag.java
@@ -1,0 +1,63 @@
+package com.thebuzzmedia.exiftool.core;
+
+import com.thebuzzmedia.exiftool.Tag;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static com.thebuzzmedia.exiftool.Constants.SEPARATOR;
+
+/**
+ * Class that can represent any tag, not just the standard tags.
+ * <p>
+ * Since the type of value is unknown, typed parsing is not possible,
+ * and the tag does not know whether multiple values are expected or not.
+ * Consequently, when parsing, it returns a String[] regardless of whether
+ * the tag will ever have multiple values. Further parsing is then up to the caller.
+ *
+ * @author David Edwards (david@more.fool.me.uk)
+ */
+
+public class UnspecifiedTag implements Tag {
+
+	private String name;
+
+	public UnspecifiedTag(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String getDisplayName() {
+		return name;
+	}
+
+	@Override
+	public <T> T parse(String value) {
+		// Clearly this won't work if caller is expecting anything other than
+		// a string array. This is due to the way the {@link Tag} interface is designed.
+		return (T) value.split(Pattern.quote(SEPARATOR));
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		UnspecifiedTag that = (UnspecifiedTag) o;
+		return Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
+	}
+}

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/AllTagHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/AllTagHandler.java
@@ -17,7 +17,6 @@
 
 package com.thebuzzmedia.exiftool.core.handlers;
 
-import com.google.common.base.Optional;
 import com.thebuzzmedia.exiftool.Tag;
 import com.thebuzzmedia.exiftool.core.UnspecifiedTag;
 
@@ -33,7 +32,7 @@ import com.thebuzzmedia.exiftool.core.UnspecifiedTag;
 public class AllTagHandler extends BaseTagHandler {
 
 	@Override
-	Optional<? extends Tag> toTag(String name) {
-		return Optional.of(new UnspecifiedTag(name));
+	Tag toTag(String name) {
+		return new UnspecifiedTag(name);
 	}
 }

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/AllTagHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/AllTagHandler.java
@@ -17,22 +17,23 @@
 
 package com.thebuzzmedia.exiftool.core.handlers;
 
+import com.google.common.base.Optional;
 import com.thebuzzmedia.exiftool.Tag;
-import com.thebuzzmedia.exiftool.process.OutputHandler;
+import com.thebuzzmedia.exiftool.core.UnspecifiedTag;
 
-import java.util.Map;
+/**
+ * Read all tags line by line.
+ *
+ * <br>
+ *
+ * This class is not thread-safe and should be used to
+ * read exiftool output from one thread (should not be shared across
+ * several threads).
+ */
+public class AllTagHandler extends BaseTagHandler {
 
-public interface TagHandler extends OutputHandler {
-
-	/**
-	 * Get all tags that have been extracted.
-	 * @return map of tags to their values
-	 */
-	Map<Tag, String> getTags();
-
-	/**
-	 * Get the number of tags extracted.
-	 * @return number of tags
-	 */
-	int size();
+	@Override
+	Optional<? extends Tag> toTag(String name) {
+		return Optional.of(new UnspecifiedTag(name));
+	}
 }

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/BaseTagHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/BaseTagHandler.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2011 The Buzz Media, LLC
+ * Copyright 2015 Mickael Jeanroy <mickael.jeanroy@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thebuzzmedia.exiftool.core.handlers;
+
+import com.google.common.base.Optional;
+import com.thebuzzmedia.exiftool.Tag;
+import com.thebuzzmedia.exiftool.logs.Logger;
+import com.thebuzzmedia.exiftool.logs.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static com.thebuzzmedia.exiftool.core.handlers.StopHandler.stopHandler;
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ * Read tags line by line.
+ *
+ * <br>
+ *
+ * This class is not thread-safe and should be used to
+ * read exiftool output from one thread (should not be shared across
+ * several threads).
+ */
+public abstract class BaseTagHandler implements TagHandler {
+
+	/**
+	 * Class logger.
+	 */
+	private static final Logger log = LoggerFactory.getLogger(BaseTagHandler.class);
+
+	/**
+	 * Compiled {@link Pattern} of {@code ": "} used to split compact output from
+	 * ExifTool evenly into name/value pairs.
+	 */
+	private static final Pattern TAG_VALUE_PATTERN = Pattern.compile(": ");
+
+	/**
+	 * Map of tags found.
+	 * Each tags will be added one by one during line processing.
+	 */
+	private final Map<Tag, String> tags = new HashMap<>();
+
+	@Override
+	public boolean readLine(String line) {
+		// If line is null, then this is the end.
+		// If line is strictly equals to "{ready}", then it means that stay_open feature
+		// is enabled and this is the end of the output.
+		if (!stopHandler().readLine(line)) {
+			return false;
+		}
+
+		// Now, we are sure we can process line.
+		String[] pair = TAG_VALUE_PATTERN.split(line, 2);
+		if (pair != null && pair.length == 2) {
+			// Determine the tag represented by this value.
+			String name = pair[0];
+			String value = pair[1];
+
+			Optional<? extends Tag> tag = toTag(name);
+			if (tag.isPresent()) {
+				tags.put(tag.get(), value);
+				log.debug("Read Tag [name={}, value={}]", tag, value);
+			} else {
+				log.debug("Unable to read Tag: {}", line);
+			}
+		} else {
+			log.warn("Skipped line: {}", line);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get a {@link Tag} for the given exif name
+	 * @param name the name of the tag
+	 */
+	abstract Optional<? extends Tag> toTag(String name);
+
+	@Override
+	public Map<Tag, String> getTags() {
+		return unmodifiableMap(tags);
+	}
+
+	@Override
+	public int size() {
+		return tags.size();
+	}
+}

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/BaseTagHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/BaseTagHandler.java
@@ -17,7 +17,6 @@
 
 package com.thebuzzmedia.exiftool.core.handlers;
 
-import com.google.common.base.Optional;
 import com.thebuzzmedia.exiftool.Tag;
 import com.thebuzzmedia.exiftool.logs.Logger;
 import com.thebuzzmedia.exiftool.logs.LoggerFactory;
@@ -73,9 +72,9 @@ public abstract class BaseTagHandler implements TagHandler {
 			String name = pair[0];
 			String value = pair[1];
 
-			Optional<? extends Tag> tag = toTag(name);
-			if (tag.isPresent()) {
-				tags.put(tag.get(), value);
+			final Tag tag = toTag(name);
+			if (tag != null) {
+				tags.put(tag, value);
 				log.debug("Read Tag [name={}, value={}]", tag, value);
 			} else {
 				log.debug("Unable to read Tag: {}", line);
@@ -91,7 +90,7 @@ public abstract class BaseTagHandler implements TagHandler {
 	 * Get a {@link Tag} for the given exif name
 	 * @param name the name of the tag
 	 */
-	abstract Optional<? extends Tag> toTag(String name);
+	abstract Tag toTag(String name);
 
 	@Override
 	public Map<Tag, String> getTags() {

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/StandardTagHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/StandardTagHandler.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2011 The Buzz Media, LLC
+ * Copyright 2015 Mickael Jeanroy <mickael.jeanroy@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thebuzzmedia.exiftool.core.handlers;
+
+import com.google.common.base.Optional;
+import com.thebuzzmedia.exiftool.Tag;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ * Read specified input tags line by line.
+ *
+ * <br>
+ *
+ * This class is not thread-safe and should be used to
+ * read exiftool output from one thread (should not be shared across
+ * several threads).
+ */
+public class StandardTagHandler extends BaseTagHandler {
+
+	/**
+	 * List of expected inputs.
+	 */
+	private final Map<String, Tag> inputs;
+
+	/**
+	 * Create handler with expected list of tags to parse.
+	 *
+	 * @param tags Expected list of tags.
+	 */
+	public StandardTagHandler(Collection<? extends Tag> tags) {
+		Map<String, Tag> inputs = new HashMap<>();
+		for (Tag tag : tags) {
+			inputs.put(tag.getDisplayName(), tag);
+		}
+
+		this.inputs = unmodifiableMap(inputs);
+	}
+
+	@Override
+	Optional<? extends Tag> toTag(String name) {
+		// Return the tag a only if we were able to map the name back
+		// to a Tag instance. If not, then this is an unknown/unexpected
+		// tag return value and we skip it since we cannot translate it
+		// back to one of our supported tags.
+		return Optional.fromNullable(inputs.get(name));
+	}
+}

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/StandardTagHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/StandardTagHandler.java
@@ -17,7 +17,6 @@
 
 package com.thebuzzmedia.exiftool.core.handlers;
 
-import com.google.common.base.Optional;
 import com.thebuzzmedia.exiftool.Tag;
 
 import java.util.Collection;
@@ -57,11 +56,11 @@ public class StandardTagHandler extends BaseTagHandler {
 	}
 
 	@Override
-	Optional<? extends Tag> toTag(String name) {
+	Tag toTag(String name) {
 		// Return the tag a only if we were able to map the name back
 		// to a Tag instance. If not, then this is an unknown/unexpected
 		// tag return value and we skip it since we cannot translate it
 		// back to one of our supported tags.
-		return Optional.fromNullable(inputs.get(name));
+		return inputs.get(name);
 	}
 }

--- a/src/test/java/com/thebuzzmedia/exiftool/core/UnspecifiedTagTest.java
+++ b/src/test/java/com/thebuzzmedia/exiftool/core/UnspecifiedTagTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2011 The Buzz Media, LLC
+ * Copyright 2015 Mickael Jeanroy <mickael.jeanroy@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thebuzzmedia.exiftool.core;
+
+import com.thebuzzmedia.exiftool.Tag;
+import org.junit.Test;
+
+import static com.thebuzzmedia.exiftool.Constants.SEPARATOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UnspecifiedTagTest {
+
+	@Test
+	public void it_should_pass_through_single_value_on_parse() {
+		final String value = "foo";
+		final Tag tag = new UnspecifiedTag("CustomTag");
+		final String[] result = tag.parse(value);
+		assertThat(result)
+				.hasSize(1);
+		assertThat(result[0])
+				.isNotNull()
+				.isNotEmpty()
+				.isEqualTo(value);
+	}
+
+	@Test
+	public void it_should_pass_through_multiple_value_on_parse() {
+		final String value = "foo" + SEPARATOR + "bar";
+		final Tag tag = new UnspecifiedTag("CustomTag");
+		final String[] result = tag.parse(value);
+		assertThat(result)
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(2)
+				.isEqualTo(new String[]{"foo", "bar"});
+	}
+}

--- a/src/test/java/com/thebuzzmedia/exiftool/core/handlers/StandardTagHandlerTest.java
+++ b/src/test/java/com/thebuzzmedia/exiftool/core/handlers/StandardTagHandlerTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2011 The Buzz Media, LLC
+ * Copyright 2015 Mickael Jeanroy <mickael.jeanroy@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.thebuzzmedia.exiftool.core.handlers;
+
+import com.thebuzzmedia.exiftool.Tag;
+import com.thebuzzmedia.exiftool.core.StandardTag;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StandardTagHandlerTest {
+
+	private List<? extends Tag> inputs;
+
+	@Before
+	public void setUp() {
+		inputs = asList(
+			StandardTag.APERTURE,
+			StandardTag.ARTIST
+		);
+	}
+
+	@Test
+	public void it_should_read_null_line() {
+		StandardTagHandler handler = new StandardTagHandler(inputs);
+		boolean hasNext = handler.readLine(null);
+		assertThat(hasNext).isFalse();
+		assertThat(handler.getTags())
+			.isNotNull()
+			.isEmpty();
+	}
+
+	@Test
+	public void it_should_read_last_line() {
+		StandardTagHandler handler = new StandardTagHandler(inputs);
+		boolean hasNext = handler.readLine("{ready}");
+		assertThat(hasNext).isFalse();
+		assertThat(handler.getTags())
+			.isNotNull()
+			.isEmpty();
+	}
+
+	@Test
+	public void it_should_read_tag_line() {
+		Tag tag = StandardTag.ARTIST;
+		String value = "foobar";
+
+		StandardTagHandler handler = new StandardTagHandler(inputs);
+		boolean hasNext = handler.readLine(tag.getName() + ": " + value);
+
+		assertThat(hasNext).isTrue();
+		assertThat(handler.getTags())
+			.isNotNull()
+			.isNotEmpty()
+			.hasSize(1)
+			.containsEntry(tag, value);
+	}
+
+	@Test
+	public void it_should_read_tag_line_with_additional_pattern() {
+		Tag tag = StandardTag.ARTIST;
+		String value = "foobar: foo";
+
+		StandardTagHandler handler = new StandardTagHandler(inputs);
+		handler.readLine(tag.getName() + ": " + value);
+
+		assertThat(handler.getTags())
+			.isNotNull()
+			.isNotEmpty()
+			.hasSize(1)
+			.containsEntry(tag, value);
+	}
+}

--- a/src/test/java/com/thebuzzmedia/exiftool/it/img/AbstractExifToolImgIT.java
+++ b/src/test/java/com/thebuzzmedia/exiftool/it/img/AbstractExifToolImgIT.java
@@ -33,6 +33,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.util.Map;
 
+import static com.thebuzzmedia.exiftool.tests.TagUtils.parseTags;
 import static com.thebuzzmedia.exiftool.tests.TestConstants.EXIF_TOOL;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -83,6 +84,11 @@ public abstract class AbstractExifToolImgIT {
 	}
 
 	@Test
+	public void testGetAllImageMeta() throws Exception {
+		verifyGetAllMeta(exifTool);
+	}
+
+	@Test
 	public void testGetImageMeta_stay_open() throws Exception {
 		verifyGetMeta(exifToolStayOpen);
 	}
@@ -116,6 +122,11 @@ public abstract class AbstractExifToolImgIT {
 	private void verifyGetMeta(ExifTool exifTool) throws Exception {
 		File file = new File("src/test/resources/images/" + image());
 		checkMeta(exifTool, file, StandardTag.values(), expectations());
+	}
+
+	private void verifyGetAllMeta(ExifTool exifTool) throws Exception {
+		File file = new File("src/test/resources/images/" + image());
+		checkAllMetaContains(exifTool, file, expectations());
 	}
 
 	private void verifySetMeta(ExifTool exifTool) throws Exception {
@@ -154,6 +165,29 @@ public abstract class AbstractExifToolImgIT {
 			assertThat(result)
 				.overridingErrorMessage(String.format("Result should contain tag %s with value %s", tag, expectation))
 				.isEqualToIgnoringCase(expectation);
+		}
+	}
+
+	private void checkAllMetaContains(ExifTool exifTool, File image, Map<Tag, String> expectations) throws Exception {
+		Map<Tag, String> results = exifTool.getImageMeta(image, StandardFormat.HUMAN_READABLE);
+		assertThat(results)
+				.isNotNull()
+				.isNotEmpty();
+
+		assertThat(results.size())
+				.isGreaterThanOrEqualTo(expectations.size());
+
+		Map<String, Object> parsedResults = parseTags(results);
+		for (Map.Entry<Tag, String> entry : expectations.entrySet()) {
+			Tag tag = entry.getKey();
+			assertThat(parsedResults)
+					.overridingErrorMessage(String.format("Result should contain tag %s", tag))
+					.containsKey(tag.getDisplayName());
+
+			Object result = parsedResults.get(tag.getName());
+			assertThat(((String[])result)[0])
+					.overridingErrorMessage(String.format("Result should contain tag %s with value %s", tag, entry.getValue()))
+					.isEqualToIgnoringCase(entry.getValue());
 		}
 	}
 

--- a/src/test/java/com/thebuzzmedia/exiftool/tests/TagUtils.java
+++ b/src/test/java/com/thebuzzmedia/exiftool/tests/TagUtils.java
@@ -15,24 +15,33 @@
  * limitations under the License.
  */
 
-package com.thebuzzmedia.exiftool.core.handlers;
+package com.thebuzzmedia.exiftool.tests;
 
 import com.thebuzzmedia.exiftool.Tag;
-import com.thebuzzmedia.exiftool.process.OutputHandler;
 
+import java.util.HashMap;
 import java.util.Map;
 
-public interface TagHandler extends OutputHandler {
+/**
+ * Static utilities for tags.
+ */
+public final class TagUtils {
+
+	private TagUtils() {
+	}
 
 	/**
-	 * Get all tags that have been extracted.
-	 * @return map of tags to their values
+	 * Parse tag results into a map of tag names to parsed values
+	 * @param tags map of tags to values
+	 * @return map of tag names to parsed values
 	 */
-	Map<Tag, String> getTags();
-
-	/**
-	 * Get the number of tags extracted.
-	 * @return number of tags
-	 */
-	int size();
+	public static Map<String, Object> parseTags(Map<Tag, String> tags) {
+		final Map<String, Object> map = new HashMap<>(tags.size());
+		for(Map.Entry<Tag, String> entry : tags.entrySet()) {
+			String displayName = entry.getKey().getDisplayName();
+			Object value = entry.getKey().parse(entry.getValue());
+			map.put(displayName, value);
+		}
+		return map;
+	}
 }


### PR DESCRIPTION
Support retrieving all tags by adding a couple of new methods to the ExifTool class.

The change required a new Tag implementation, and a new output handler, so I pulled the common aspects of TagHandler into a base class.

The new tag handler returns a map of "unspecified" tags. I kept it simple, so it doesn't try and match up the standard tags. Parsing therefore doesn't know the expected datatype of any of the tags, so it converts them all into arrays of strings, even if they only have a single value. This seemed like that simplest approach, leaving it up to the caller to decide what to do with each tag, but keeps the separator as an internal implementation detail.