### PR TITLE
add method for custom exiftool commands and getting the raw output fr…

### DIFF
--- a/src/main/java/com/thebuzzmedia/exiftool/ExifTool.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/ExifTool.java
@@ -527,36 +527,22 @@ public class ExifTool implements AutoCloseable {
 	}
 
 	/**
-	 * Run users custom Exiftool command on image and returns raw output from Exiftool as string
+	 * Run user's custom Exiftool command and returns raw output from Exiftool as string
 	 * This just passes the arguments to Exiftool and does not do any checking on the validity of
-	 * those arguments before passing them to Exiftool. The user is also responsible for parsing
+	 * those arguments or validity of any image file in the argument before passing them to
+	 * Exiftool. The user is also responsible for parsing
 	 * the raw output that has been returned.
 	 *
-	 * @param image Image.
+	 * @param arguments List of strings containing the commands to pass to exiftool
 	 * @return String with whatever exiftool outputs.
 	 * @throws IOException If something bad happen during I/O operations.
-	 * @throws NullPointerException If one parameter is null.
-	 * @throws com.thebuzzmedia.exiftool.exceptions.UnreadableFileException If image cannot be read.
+	 * @throws NullPointerException If parameter is null.
 	 */
-	public String getRawExifToolOutput(File image, List<String> arguments) throws IOException {
-		requireNonNull(image, "Image cannot be null and must be a valid stream of image data.");
+	public String getRawExifToolOutput(List<String> arguments) throws IOException {
 		requireNonNull(arguments, "Arguments cannot be null.");
-		isReadable(image, String.format("Unable to read the given image [%s], ensure that the image exists at the given withPath and that the executing Java process has permissions to read it.", image));
-
-		int expectedSize = arguments.size() + 2;
-		List<String> args = new ArrayList<>(expectedSize);
-
-		addAll(args, arguments);
-
-		// Add image argument.
-		args.add(image.getAbsolutePath());
-
-		// Add last argument.
-		// This argument will only be used by exiftool if stay_open flag has been set.
-		args.add("-execute");
 
 		RawOutputHandler resultHandler = new RawOutputHandler();
-		strategy.execute(executor, path, args, resultHandler);
+		strategy.execute(executor, path, arguments, resultHandler);
 
 		return resultHandler.getOutput();
 	}

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/RawOutputHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/RawOutputHandler.java
@@ -7,30 +7,31 @@ import com.thebuzzmedia.exiftool.process.OutputHandler;
 
 public class RawOutputHandler implements OutputHandler {
 
-    private final StringBuilder output;
+	private final StringBuilder output;
 
-    public RawOutputHandler() {
-      this.output = new StringBuilder();
-    }
+	public RawOutputHandler() {
+		this.output = new StringBuilder();
+	}
 
-    @Override
-    public boolean readLine(String line) {
-      // If line is null, then this is the end.
-      // If line is strictly equals to "{ready}", then it means that stay_open feature
-      // is enabled and this is the end of the output.
-      if (!stopHandler().readLine(line)) {
-        return false;
-      }
+	@Override
+	public boolean readLine(String line) {
+		// If line is null, then this is the end.
+		// If line is strictly equals to "{ready}", then it means that stay_open feature
+		// is enabled and this is the end of the output.
+		if (!stopHandler().readLine(line)) {
+			return false;
+		}
 
-      if (output.length() > 0) {
-        output.append(Constants.BR);
-      }
-      output.append(line);
+		if (output.length() > 0) {
+			output.append(Constants.BR);
+		}
+		output.append(line);
 
-      return true;
-    }
+		return true;
+	}
 
-    public String getOutput() {
-      return output.toString();
-    }
+	public String getOutput() {
+		// output the raw string that exiftool outputes
+		return output.toString();
+	}
 }

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/RawOutputHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/RawOutputHandler.java
@@ -1,0 +1,36 @@
+package com.thebuzzmedia.exiftool.core.handlers;
+
+import static com.thebuzzmedia.exiftool.core.handlers.StopHandler.stopHandler;
+
+import com.thebuzzmedia.exiftool.Constants;
+import com.thebuzzmedia.exiftool.process.OutputHandler;
+
+public class RawOutputHandler implements OutputHandler {
+
+    private final StringBuilder output;
+
+    public RawOutputHandler() {
+      this.output = new StringBuilder();
+    }
+
+    @Override
+    public boolean readLine(String line) {
+      // If line is null, then this is the end.
+      // If line is strictly equals to "{ready}", then it means that stay_open feature
+      // is enabled and this is the end of the output.
+      if (!stopHandler().readLine(line)) {
+        return false;
+      }
+
+      if (output.length() > 0) {
+        output.append(Constants.BR);
+      }
+      output.append(line);
+
+      return true;
+    }
+
+    public String getOutput() {
+      return output.toString();
+    }
+}

--- a/src/test/java/com/thebuzzmedia/exiftool/ExifTool_getRawExifToolOutput_Test.java
+++ b/src/test/java/com/thebuzzmedia/exiftool/ExifTool_getRawExifToolOutput_Test.java
@@ -1,0 +1,147 @@
+package com.thebuzzmedia.exiftool;
+
+import static com.thebuzzmedia.exiftool.tests.MockitoTestUtils.anyListOf;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.thebuzzmedia.exiftool.exceptions.UnreadableFileException;
+import com.thebuzzmedia.exiftool.process.Command;
+import com.thebuzzmedia.exiftool.process.CommandExecutor;
+import com.thebuzzmedia.exiftool.process.CommandResult;
+import com.thebuzzmedia.exiftool.process.OutputHandler;
+import com.thebuzzmedia.exiftool.tests.builders.CommandResultBuilder;
+import com.thebuzzmedia.exiftool.tests.builders.FileBuilder;
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class ExifTool_getRawExifToolOutput_Test {
+  private String path;
+  private CommandExecutor executor;
+  private ExecutionStrategy strategy;
+  private List<String> args;
+
+  private ExifTool exifTool;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    executor = mock(CommandExecutor.class);
+    strategy = mock(ExecutionStrategy.class);
+    path = "exiftool";
+    args = asList("-a", "-u", "-g1", "-j");
+    CommandResult cmd = new CommandResultBuilder().output("9.36").build();
+    when(executor.execute(any(Command.class))).thenReturn(cmd);
+    when(strategy.isSupported(any(Version.class))).thenReturn(true);
+
+    exifTool = new ExifTool(path, executor, strategy);
+
+    reset(executor);
+  }
+
+  @Test
+  void it_should_fail_if_image_is_null() {
+    assertThatThrownBy(() -> exifTool.getRawExifToolOutput(null, args))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Image cannot be null and must be a valid stream of image data.");
+  }
+
+  @Test
+  void it_should_fail_if_arguments_is_null() {
+    assertThatThrownBy(() -> exifTool.getRawExifToolOutput(mock(File.class), null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Arguments cannot be null.");
+  }
+
+  @Test
+  void it_should_fail_with_unknown_file() {
+    File image = new FileBuilder("foo.png").exists(false).build();
+    assertThatThrownBy(() -> exifTool.getRawExifToolOutput(image, args))
+        .isInstanceOf(UnreadableFileException.class)
+        .hasMessage(
+            "Unable to read the given image [/tmp/foo.png], " +
+                "ensure that the image exists at the given withPath and that the " +
+                "executing Java process has permissions to read it."
+        );
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void it_should_get_raw_image_metadata() throws Exception {
+    // Given
+    File image = new FileBuilder("foo.png").build();
+
+    String rawOutput = "[{\n"
+        + "\"SourceFile\": \"tmp/foo.png\",\n"
+        + "\"IFD0\": {\n"
+        + "\"Make\": \"HTC\",\n"
+        + "\"Model\": \"myTouch 4G\",\n"
+        + "\"XResolution\": 72,\n"
+        + "\"YResolution\": 72,\n"
+        + "\"ResolutionUnit\": \"inches\",\n"
+        + "\"YCbCrPositioning\": \"Centered\"\n"
+        + "},\n"
+        + "}]";
+
+    doAnswer(new ReadRawOutputAnswer(rawOutput, "{ready}")).when(strategy).execute(
+        same(executor), same(path), anyListOf(String.class), any(OutputHandler.class)
+    );
+
+    // When
+    String result = exifTool.getRawExifToolOutput(image, args);
+
+    // Then
+    ArgumentCaptor<List<String>> argsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(strategy).execute(same(executor), same(path), argsCaptor.capture(), any(OutputHandler.class));
+
+    List<String> arguments = argsCaptor.getValue();
+    assertThat(arguments).isNotEmpty().containsExactly(
+        "-a",
+        "-u",
+        "-g1",
+        "-j",
+        "/tmp/foo.png",
+        "-execute"
+    );
+    assertThat(result).isEqualTo("hello");
+  }
+
+  private static final class ReadRawOutputAnswer implements Answer<Void> {
+    private final String rawOutput;
+
+    private final String end;
+
+    private ReadRawOutputAnswer(String rawOutput, String end) {
+      this.rawOutput = rawOutput;
+      this.end = end;
+    }
+
+    @Override
+    public Void answer(InvocationOnMock invocation) {
+      OutputHandler handler = (OutputHandler) invocation.getArguments()[3];
+      String[]lines = rawOutput.split(System.getProperty("line.separator"));
+      // read raw output
+      for(String tmpLine : lines){
+        handler.readLine(tmpLine);
+      }
+
+      // Read last line
+      handler.readLine(end);
+
+      return null;
+    }
+  }
+}

--- a/src/test/java/com/thebuzzmedia/exiftool/core/handlers/RawOutputHandlerTest.java
+++ b/src/test/java/com/thebuzzmedia/exiftool/core/handlers/RawOutputHandlerTest.java
@@ -6,36 +6,35 @@ import org.junit.jupiter.api.Test;
 
 public class RawOutputHandlerTest {
 
-  @Test
-  void it_should_read_null_line() {
-    RawOutputHandler handler = new RawOutputHandler();
-    boolean hasNext = handler.readLine(null);
-    assertThat(hasNext).isFalse();
-    assertThat(handler.getOutput()).isNotNull().isEmpty();
-  }
+	@Test
+	void it_should_read_null_line() {
+		RawOutputHandler handler = new RawOutputHandler();
+		boolean hasNext = handler.readLine(null);
+		assertThat(hasNext).isFalse();
+		assertThat(handler.getOutput()).isNotNull().isEmpty();
+	}
 
-  @Test
-  void it_should_read_last_line() {
-    RawOutputHandler handler = new RawOutputHandler();
-    boolean hasNext = handler.readLine("{ready}");
-    assertThat(hasNext).isFalse();
-    assertThat(handler.getOutput()).isNotNull().isEmpty();
-  }
+	@Test
+	void it_should_read_last_line() {
+		RawOutputHandler handler = new RawOutputHandler();
+		boolean hasNext = handler.readLine("{ready}");
+		assertThat(hasNext).isFalse();
+		assertThat(handler.getOutput()).isNotNull().isEmpty();
+	}
 
-  @Test
-  void it_should_read_line() {
-    String rawOutput = "[{\"SourceFile\": \"tmp/foo.png\",\"IFD0\": {\"Make\": \"HTC\","
-        + "\"Model\": \"myTouch 4G\", \"XResolution\": 72, \"YResolution\": 72,"
-        + "\"ResolutionUnit\": \"inches\", \"YCbCrPositioning\": \"Centered\"},}]";
+	@Test
+	void it_should_read_line() {
+		String rawOutput = "[{\"SourceFile\": \"tmp/foo.jpg\",\"IFD0\": {\"Make\": \"HTC\","
+			+ "\"Model\": \"myTouch 4G\", \"XResolution\": 72, \"YResolution\": 72,"
+			+ "\"ResolutionUnit\": \"inches\", \"YCbCrPositioning\": \"Centered\"},}]";
 
-    RawOutputHandler handler = new RawOutputHandler();
-    boolean hasNext = handler.readLine(rawOutput);
+	RawOutputHandler handler = new RawOutputHandler();
+	boolean hasNext = handler.readLine(rawOutput);
 
-    String result = handler.getOutput();
-    assertThat(hasNext).isTrue();
-    assertThat(result).hasSize(rawOutput.length());
+		String result = handler.getOutput();
+		assertThat(hasNext).isTrue();
+		assertThat(result).hasSize(rawOutput.length());
 
-    assertThat(result).isEqualTo(rawOutput);
-  }
-
+		assertThat(result).isEqualTo(rawOutput);
+	}
 }

--- a/src/test/java/com/thebuzzmedia/exiftool/core/handlers/RawOutputHandlerTest.java
+++ b/src/test/java/com/thebuzzmedia/exiftool/core/handlers/RawOutputHandlerTest.java
@@ -1,0 +1,41 @@
+package com.thebuzzmedia.exiftool.core.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class RawOutputHandlerTest {
+
+  @Test
+  void it_should_read_null_line() {
+    RawOutputHandler handler = new RawOutputHandler();
+    boolean hasNext = handler.readLine(null);
+    assertThat(hasNext).isFalse();
+    assertThat(handler.getOutput()).isNotNull().isEmpty();
+  }
+
+  @Test
+  void it_should_read_last_line() {
+    RawOutputHandler handler = new RawOutputHandler();
+    boolean hasNext = handler.readLine("{ready}");
+    assertThat(hasNext).isFalse();
+    assertThat(handler.getOutput()).isNotNull().isEmpty();
+  }
+
+  @Test
+  void it_should_read_line() {
+    String rawOutput = "[{\"SourceFile\": \"tmp/foo.png\",\"IFD0\": {\"Make\": \"HTC\","
+        + "\"Model\": \"myTouch 4G\", \"XResolution\": 72, \"YResolution\": 72,"
+        + "\"ResolutionUnit\": \"inches\", \"YCbCrPositioning\": \"Centered\"},}]";
+
+    RawOutputHandler handler = new RawOutputHandler();
+    boolean hasNext = handler.readLine(rawOutput);
+
+    String result = handler.getOutput();
+    assertThat(hasNext).isTrue();
+    assertThat(result).hasSize(rawOutput.length());
+
+    assertThat(result).isEqualTo(rawOutput);
+  }
+
+}


### PR DESCRIPTION
This will allow a user to create their own exiftool command and get the raw output from exiftool.  I was interested in getting the family name of the tag but that is not supported as well as getting a response of a json string.  So for example this pr will allow a command like:

exiftool -a -u -g1 -j

This Exif Command -a is for all metadata so includes duplicate tags -u is to include any unknown tags -g1 sorts the tags by group for family 1 and -j exports in json.

This way we have the family tag and some family tag can have same tag name, so keeps everything separate.  So can use the fantastic functionality of stay_open, but have greater flexibility in the commands we can run.

This would seem to address 3 of the lodged issues:
https://github.com/mjeanroy/exiftool/issues/289
https://github.com/mjeanroy/exiftool/issues/117
https://github.com/mjeanroy/exiftool/issues/247
As well as allowing a workaround for this issue and others like it that want to better control the Exiftool options when getting metadata:
https://github.com/mjeanroy/exiftool/issues/442