### PR TITLE
Misc. Cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 ### Description
 
-*The goal and main features of this fork did not changed, so this description is the same as the original library*
+*The goal and main features of this fork did not change, so this description is the same as the original library*
 
 This project represents the most robust Java integrations with Phil Harvey's
 excellent ExifTool available.
 
-The goal of this project was to provide such a tight, well designed and performant
+The goal of this project was to provide such a tight, well-designed and performant
 integration with ExifTool that any Java developer using the class would have no
 idea that they weren't simply calling into a standard Java library while still
 being able to leverage the unmatched robustness of ExifTool.
@@ -38,7 +38,7 @@ checking and error reporting during instantiation and use.
 For example, if you specify that you want to use `stay_open` support, the
 ExifTool class will actually check the native ExifTool executable for support
 for that feature before allowing the feature to be turned on and report the
-problem to the caller along with potential work-arounds if necessary.
+problem to the caller along with potential workarounds if necessary.
 
 Additionally, all external calls to the process are safely wrapped and reported
 with detailed exceptions if problems arise instead of just letting unknown
@@ -59,11 +59,11 @@ This library is a fork of [https://github.com/rkalla/exiftool](https://github.co
 - ExifTool is now thread-safe.
 - Integration with `slf4j` and `log4j`.
 
-More informations below.
+More information below.
 
 ### Support
 
-This library is tested against Java >= 7, Linux and Windows.
+This library is tested against Java >= 8, Linux and Windows.
 
 
 ### Installation
@@ -203,9 +203,7 @@ import com.thebuzzmedia.exiftool.Tag;
 import com.thebuzzmedia.exiftool.core.StandardTag;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -241,16 +239,13 @@ public class ExifParser {
 
     try {
       for (final String image : args) {
-        executor.submit(new Runnable() {
-          @Override
-          public void run() {
+        executor.submit(() -> {
             try {
               System.out.println("Tags: " + parse(image));
             }
             catch (Exception ex) {
               ex.printStackTrace();
             }
-          }
         });
       }
     } finally {
@@ -280,7 +275,7 @@ Benchmark [tags=49, images=10, iterations=25]
 You can see that utilizing the -stay_open functionality provided in ExifTool
 you can realize magnitudes times more performance.
 
-Also the bigger of a test you run (more iterations) the bigger the performance
+Also, the bigger of a test you run (more iterations) the bigger the performance
 margin increases.
 
 ### Troubleshooting
@@ -316,7 +311,7 @@ Because of this and because of the expectation that ExifTool in daemon mode
 will be the primary use-case for this class, limited support for `InputStream`
 parsing was designed out of this class.
 
-- Do I need to manually call `close()` to cleanup a daemon ExifTool?
+- Do I need to manually call `close()` to clean up a daemon ExifTool?
 
 This is done automatically for you when `exifTool` instance is garbage collected or
 via the cleanup thread the class employs when a daemon instance of ExifTool is created.
@@ -324,7 +319,7 @@ Unless you modified the delay of the cleanup thread (and set it to 0 or less), t
 automatic cleanup thread is enabled and will clean up those resources for
 you after the specified amount of inactivity.
 
-Nevetheless, I suggest you to use exiftool with a `try-with-resource` and to force `close`
+Nevertheless, I suggest you to use exiftool with a `try-with-resource` and to force `close`
 operation when your program stops.
 
 ### Reference

--- a/src/main/java/com/thebuzzmedia/exiftool/Constants.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/Constants.java
@@ -36,5 +36,5 @@ public final class Constants {
 	/**
 	 * OS independent line break.
 	 */
-	public static final String BR = System.getProperty("line.separator");
+	public static final String BR = System.lineSeparator();
 }

--- a/src/main/java/com/thebuzzmedia/exiftool/Constants.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/Constants.java
@@ -18,7 +18,7 @@
 package com.thebuzzmedia.exiftool;
 
 /**
- * List of constants used with Exiftool.
+ * List of constants used with ExifTool.
  */
 public final class Constants {
 

--- a/src/main/java/com/thebuzzmedia/exiftool/ExecutionStrategy.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/ExecutionStrategy.java
@@ -38,7 +38,7 @@ import java.util.List;
  * </ul>
  *
  * Each implementation will define the main logic for reading and
- * writing metadata (this is the main purpose for the {@link #execute} method.
+ * writing metadata (this is the main purpose for the {@link #execute} method).
  *
  * <br>
  *
@@ -52,10 +52,10 @@ public interface ExecutionStrategy extends AutoCloseable {
 	/**
 	 * Execute exiftool command.
 	 *
-	 * @param executor ExifTool withExecutor.
-	 * @param exifTool ExifTool withPath.
+	 * @param executor  ExifTool withExecutor.
+	 * @param exifTool  ExifTool withPath.
 	 * @param arguments Command line arguments.
-	 * @param handler Handler to read command output.
+	 * @param handler   Handler to read command output.
 	 * @throws IOException If an error occurred during execution.
 	 */
 	void execute(CommandExecutor executor, String exifTool, List<String> arguments, OutputHandler handler) throws IOException;

--- a/src/main/java/com/thebuzzmedia/exiftool/ExifTool.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/ExifTool.java
@@ -54,20 +54,20 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Class used to provide a Java-like interface to Phil Harvey's excellent,
- * Perl-based <a href="http://www.sno.phy.queensu.ca/~phil/exiftool">ExifTool</a>.
- *
+ * Perl-based <a href="https://exiftool.org/">ExifTool</a>.
+ * <p>
  * There are a number of other basic Java wrappers to ExifTool available online,
  * but most of them only abstract out the actual Java-external-process execution
  * logic and do no additional work to make integration with the external
  * ExifTool any easier or intuitive from the perspective of the Java application
  * written to make use of ExifTool.
- *
- * This class was written in order to make integration with ExifTool inside of a
+ * <p>
+ * This class was written in order to make integration with ExifTool inside a
  * Java application seamless and performant with the goal being that the
- * developer can treat ExifTool as if it were written in Java, garnering all of
+ * developer can treat ExifTool as if it were written in Java, garnering all
  * the benefits with none of the added headache of managing an external native
  * process from Java.
- *
+ * <p>
  * Phil Harvey's ExifTool is written in Perl and runs on all major platforms
  * (including Windows) so no portability issues are introduced into your
  * application by utilizing this class.
@@ -97,56 +97,56 @@ import static java.util.Objects.requireNonNull;
  * </code></pre>
  *
  * Once created, usage is as simple as making calls to {@link #getImageMeta(File, Collection)} or
- * {@link #getImageMeta(File, Format, Collection)} with a list of {@link Tag} you want to pull
+ * {@link #getImageMeta(File, Format, Collection)} with a list of {@link Tag}s you want to pull
  * values for from the given image.
- *
+ * <p>
  * In this default mode, calls to {@link #getImageMeta} will automatically
  * start an external ExifTool process to handle the request. After ExifTool has
  * parsed the tag values from the file, the external process exits and this
  * class parses the result before returning it to the caller.
- *
+ * <p>
  * Results from calls to {@link #getImageMeta} are returned in a {@link Map}
  * with the {@link com.thebuzzmedia.exiftool.core.StandardTag} values as the keys and {@link String} values for every
  * tag that had a value in the image file as the values. {@link com.thebuzzmedia.exiftool.core.StandardTag}s with no
  * value found in the image are omitted from the result map.
- *
+ * <p>
  * While each {@link com.thebuzzmedia.exiftool.core.StandardTag} provides a hint at which format the resulting value
  * for that tag is returned as from ExifTool (see {@link com.thebuzzmedia.exiftool.Tag#parse(String)}), that
  * only applies to values returned with an output format of
  * {@link com.thebuzzmedia.exiftool.core.StandardFormat#NUMERIC} and it is ultimately up to the caller to decide how
  * best to parse or convert the returned values.
- *
+ * <p>
  * The {@link com.thebuzzmedia.exiftool.core.StandardTag} Enum provides the {@link com.thebuzzmedia.exiftool.Tag#parse(String)}}
- * convenience method for parsing given `String` values according to
+ * convenience method for parsing given {@link String} values according to
  * the Tag hint automatically for you if that is what you plan on doing,
  * otherwise feel free to handle the return values anyway you want.
  *
  * <h3>ExifTool -stay_open Support</h3>
  *
- * ExifTool <a href="http://u88.n24.queensu.ca/exiftool/forum/index.php/topic,1402.msg12933.html#msg12933">8.36</a>
+ * ExifTool <a href="https://exiftool.org/forum/index.php?topic=1402.msg12933#msg12933">8.36</a>
  * added a new persistent-process feature that allows ExifTool to stay
  * running in a daemon mode and continue accepting commands via a file or stdin.
- *
+ * <p>
  * This new mode is controlled via the {@code -stay_open True/False}
  * command line argument and in a busy system that is making thousands of calls
  * to ExifTool, can offer speed improvements of up to <strong>60x</strong> (yes,
  * really that much).
- *
+ * <p>
  * This feature was added to ExifTool shortly after user
- * <a href="http://www.christian-etter.de/?p=458">Christian Etter discovered</a> the overhead
+ * <a href="https://web.archive.org/web/20131204165247/http://www.christian-etter.de/?p=458">Christian Etter discovered</a> the overhead
  * for starting up a new Perl interpreter each time ExifTool is loaded accounts for
- * roughly <a href="http://u88.n24.queensu.ca/exiftool/forum/index.php/topic,1402.msg6121.html#msg6121">98.4% of the total runtime</a>.
- *
+ * roughly <a href="https://exiftool.org/forum/index.php?topic=1402.msg6121#msg6121">98.4% of the total runtime</a>.
+ * <p>
  * Support for using ExifTool in daemon mode is enabled by explicitly calling
  * {@link ExifToolBuilder#enableStayOpen()} method.
  * Calling this method will create an instance of {@link ExifTool} with {@link com.thebuzzmedia.exiftool.core.strategies.StayOpenStrategy} execution strategy.
- *
+ * <p>
  * Because this feature requires ExifTool 8.36 or later, this class will
  * actually verify support for the feature in the version of ExifTool
  * before successfully instantiating the class and will notify you via
  * an {@link com.thebuzzmedia.exiftool.exceptions.UnsupportedFeatureException} if the native
  * ExifTool doesn't support the requested feature.
- *
+ * <p>
  * In the event of an {@link com.thebuzzmedia.exiftool.exceptions.UnsupportedFeatureException}, the caller can either
  * upgrade the native ExifTool upgrade to the version required or simply avoid
  * using that feature to work around the exception.
@@ -159,12 +159,12 @@ import static java.util.Objects.requireNonNull;
  * called to clean them up when done. <strong>Fortunately</strong>, this library
  * provides an automatic cleanup mechanism that runs, by default, after 10 minutes
  * of inactivity to clean up those stray resources.
- *
+ * <p>
  * The inactivity period can be controlled by modifying the
- * {@code exifTool.processCleanupDelay} system variable. A value of <code>0</code> or
- * less disabled the automatic cleanup process and requires you to cleanup
+ * {@code exifTool.processCleanupDelay} system variable. A value of {@code 0} or
+ * less disabled the automatic cleanup process and requires you to clean up
  * ExifTool instances on your own by calling {@link #close()} manually.
- *
+ * <p>
  * You can also set this delay manually using {@link com.thebuzzmedia.exiftool.ExifToolBuilder}:
  * <pre><code>
  *     ExifTool exifTool = new ExifToolBuilder()
@@ -172,16 +172,16 @@ import static java.util.Objects.requireNonNull;
  *         .build();
  * </code></pre>
  *
- * Any class activity by way of calls to <code>getImageMeta</code> will always
+ * Any class activity by way of calls to {@code getImageMeta} will always
  * reset the inactivity timer, so in a busy system the cleanup thread could
  * potentially never run, leaving the original host ExifTool process running
  * forever (which is fine).
- *
+ * <p>
  * This design was chosen to help make using the class and not introducing
  * memory leaks and bugs into your code easier as well as making very inactive
- * instances of this class light weight while not in-use by cleaning up after
+ * instances of this class lightweight while not in-use by cleaning up after
  * themselves.
- *
+ * <p>
  * The only overhead incurred when opening the process back up is a 250-500ms
  * lag while launching the VM interpreter again on the first call (depending on
  * host machine speed and load).
@@ -191,9 +191,9 @@ import static java.util.Objects.requireNonNull;
  * If you or the cleanup thread have called {@link #close()} on an instance of
  * this class, cleaning up the host process and read/write streams, the instance
  * of this class can still be safely used. Any followup calls to
- * <code>getImageMeta</code> will simply re-instantiate all the required
+ * {@code getImageMeta} will simply re-instantiate all the required
  * resources necessary to service the call.
- *
+ * <p>
  * This can be handy behavior to be aware of when writing scheduled processing
  * jobs that may wake up every hour and process thousands of pictures then go
  * back to sleep. In order for the process to execute as fast as possible, you
@@ -205,26 +205,26 @@ import static java.util.Objects.requireNonNull;
  *
  * Extra care is taken to ensure minimal object creation or unnecessary CPU
  * overhead while communicating with the external process.
- *
+ * <p>
  * {@link Pattern}s used to split the responses from the process are explicitly
  * compiled and reused, string concatenation is minimized, Tag name lookup is
- * done via a <code>static final</code> {@link Map} shared by all instances and
+ * done via a {@code static final} {@link Map} shared by all instances and
  * so on.
- *
+ * <p>
  * Additionally, extra care is taken to utilize the most optimal code paths when
  * initiating and using the external process, for example, the
  * {@link ProcessBuilder#command(List)} method is used to avoid the copying of
  * array elements when {@link ProcessBuilder#command(String...)} is used and
  * avoiding the (hidden) use of {@link StringTokenizer} when
  * {@link Runtime#exec(String)} is called.
- *
+ * <p>
  * All of this effort was done to ensure that imgscalr and its supporting
  * classes continue to provide best-of-breed performance and memory utilization
- * in long running/high performance environments (e.g. web applications).
+ * in long-running/high performance environments (e.g. web applications).
  *
  * <h3>Thread Safety</h3>
  *
- * Instances of this class <strong>are Thread-safe</strong> (note that version 1.1 of exiftool
+ * Instances of this class <strong>are Thread-safe</strong> (note that version 1.1 of ExifTool
  * was not Thread-safe):
  *
  * <ul>
@@ -235,11 +235,11 @@ import static java.util.Objects.requireNonNull;
  *   </li>
  * </ul>
  *
- * If you want to use ExifTool in a multi-threaded environment, I strongly suggest you to
+ * If you want to use ExifTool in a multithreaded environment, I strongly suggest you to
  * use a pool size: this is available out of the box. With this configuration, you will get at most
  * a number of open process equal to the size of the pool. If a thread is trying to parse an image and no process
  * is available, then ExifTool will wait for a process to be available.
- *
+ * <p>
  * Here is the configuration to get a pool:
  *
  * <pre><code>
@@ -250,27 +250,27 @@ import static java.util.Objects.requireNonNull;
  *
  * <h3>Why ExifTool?</h3>
  *
- * <a href="http://www.sno.phy.queensu.ca/~phil/exiftool">ExifTool</a> is
+ * <a href="https://exiftool.org/">ExifTool</a> is
  * written in Perl and requires an external process call from Java to make use
  * of.
- *
+ * <p>
  * While this would normally preclude a piece of software from inclusion into
  * the imgscalr library (more complex integration), there is no other image
  * metadata piece of software available as robust, complete and well-tested as
  * ExifTool. In addition, ExifTool already runs on all major platforms
  * (including Windows), so there was not a lack of portability introduced by
  * providing an integration for it.
- *
+ * <p>
  * Allowing it to be used from Java is a boon to any Java project that needs the
  * ability to read/write image-metadata from almost
- * <a href="http://www.sno.phy.queensu.ca/~phil/exiftool/#supported">any image or video file</a> format.
+ * <a href="https://exiftool.org/#supported">any image or video file</a> format.
  *
  * <h3>Alternatives</h3>
  *
  * If integration with an external Perl process is something your app cannot do
  * and you still need image metadata-extraction capability, Drew Noakes has
  * written the 2nd most robust image metadata library I have come
- * across: <a href="http://drewnoakes.com/drewnoakes.com/code/exif/">Metadata Extractor</a>
+ * across: <a href="https://github.com/drewnoakes/metadata-extractor">Metadata Extractor</a>
  * that you might want to look at.
  *
  * @author Riyad Kalla (software@thebuzzmedia.com)
@@ -305,31 +305,31 @@ public class ExifTool implements AutoCloseable {
 
 	/**
 	 * Exiftool Path.
-	 * Path is first read from `exiftool.withPath` system property,
-	 * otherwise `exiftool` must be globally available.
+	 * Path is first read from {@code exiftool.withPath} system property,
+	 * otherwise {@code exiftool} must be globally available.
 	 */
 	private final String path;
 
 	/**
-	 * This is the version detected on exiftool executable.
+	 * This is the version detected on ExifTool executable.
 	 * This version depends on executable given on instantiation.
 	 */
 	private final Version version;
 
 	/**
 	 * ExifTool execution strategy.
-	 * This strategy implement how exiftool is effectively used (as one-shot
-	 * process or with `stay_open` flag).
+	 * This strategy implement how ExifTool is effectively used (as one-shot
+	 * process or with {@code stay_open} flag).
 	 */
 	private final ExecutionStrategy strategy;
 
 	/**
 	 * Create new ExifTool instance.
-	 * When exiftool is created, it will try to activate some features.
-	 * If feature is not available on this specific exiftool version, then
-	 * an it an {@link UnsupportedFeatureException} will be thrown.
+	 * When ExifTool is created, it will try to activate some features.
+	 * If a feature is not available on this specific exiftool version, then
+	 * an {@link UnsupportedFeatureException} will be thrown.
 	 *
-	 * @param path ExifTool withPath.
+	 * @param path     ExifTool withPath.
 	 * @param executor Executor used to handle command line.
 	 * @param strategy Execution strategy.
 	 */
@@ -362,8 +362,8 @@ public class ExifTool implements AutoCloseable {
 	}
 
 	/**
-	 * Stop `ExifTool` client.
-	 *
+	 * Stop {@code ExifTool} client.
+	 * <p>
 	 * <strong>NOTE</strong>: Calling this method does not preclude this
 	 * instance of {@link ExifTool} from being re-used, it merely disposes of
 	 * the native and internal resources until the next call to
@@ -407,9 +407,9 @@ public class ExifTool implements AutoCloseable {
 	 *
 	 * @param image Image.
 	 * @return Pair of tag associated with the value.
-	 * @throws IOException If something bad happen during I/O operations.
-	 * @throws NullPointerException If one parameter is null.
-	 * @throws IllegalArgumentException If list of tag is empty.
+	 * @throws IOException                                                  If something bad happen during I/O operations.
+	 * @throws NullPointerException                                         If one parameter is null.
+	 * @throws IllegalArgumentException                                     If list of tag is empty.
 	 * @throws com.thebuzzmedia.exiftool.exceptions.UnreadableFileException If image cannot be read.
 	 */
 	public Map<Tag, String> getImageMeta(File image) throws IOException {
@@ -419,12 +419,12 @@ public class ExifTool implements AutoCloseable {
 	/**
 	 * Parse image metadata for all tags.
 	 *
-	 * @param image Image.
+	 * @param image  Image.
 	 * @param format Output format.
 	 * @return Pair of tag associated with the value.
-	 * @throws IOException If something bad happen during I/O operations.
-	 * @throws NullPointerException If one parameter is null.
-	 * @throws IllegalArgumentException If list of tag is empty.
+	 * @throws IOException                                                  If something bad happen during I/O operations.
+	 * @throws NullPointerException                                         If one parameter is null.
+	 * @throws IllegalArgumentException                                     If list of tag is empty.
 	 * @throws com.thebuzzmedia.exiftool.exceptions.UnreadableFileException If image cannot be read.
 	 */
 	public Map<Tag, String> getImageMeta(File image, Format format) throws IOException {
@@ -435,12 +435,12 @@ public class ExifTool implements AutoCloseable {
 	/**
 	 * Parse image metadata for all tags.
 	 *
-	 * @param image Image.
+	 * @param image   Image.
 	 * @param options ExifTool options.
 	 * @return Pair of tag associated with the value.
-	 * @throws IOException If something bad happen during I/O operations.
-	 * @throws NullPointerException If one parameter is null.
-	 * @throws IllegalArgumentException If list of tag is empty.
+	 * @throws IOException                                                  If something bad happen during I/O operations.
+	 * @throws NullPointerException                                         If one parameter is null.
+	 * @throws IllegalArgumentException                                     If list of tag is empty.
 	 * @throws com.thebuzzmedia.exiftool.exceptions.UnreadableFileException If image cannot be read.
 	 */
 	public Map<Tag, String> getImageMeta(File image, ExifToolOptions options) throws IOException {
@@ -455,11 +455,11 @@ public class ExifTool implements AutoCloseable {
 	 * Output format is numeric.
 	 *
 	 * @param image Image.
-	 * @param tags List of tags to extract.
+	 * @param tags  List of tags to extract.
 	 * @return Pair of tag associated with the value.
-	 * @throws IOException If something bad happen during I/O operations.
-	 * @throws NullPointerException If one parameter is null.
-	 * @throws IllegalArgumentException If list of tag is empty.
+	 * @throws IOException                                                  If something bad happen during I/O operations.
+	 * @throws NullPointerException                                         If one parameter is null.
+	 * @throws IllegalArgumentException                                     If list of tag is empty.
 	 * @throws com.thebuzzmedia.exiftool.exceptions.UnreadableFileException If image cannot be read.
 	 */
 	public Map<Tag, String> getImageMeta(File image, Collection<? extends Tag> tags) throws IOException {
@@ -469,13 +469,13 @@ public class ExifTool implements AutoCloseable {
 	/**
 	 * Parse image metadata.
 	 *
-	 * @param image Image.
+	 * @param image  Image.
 	 * @param format Output format.
-	 * @param tags List of tags to extract.
+	 * @param tags   List of tags to extract.
 	 * @return Pair of tag associated with the value.
-	 * @throws IOException If something bad happen during I/O operations.
-	 * @throws NullPointerException If one parameter is null.
-	 * @throws IllegalArgumentException If list of tag is empty.
+	 * @throws IOException                                                  If something bad happen during I/O operations.
+	 * @throws NullPointerException                                         If one parameter is null.
+	 * @throws IllegalArgumentException                                     If list of tag is empty.
 	 * @throws com.thebuzzmedia.exiftool.exceptions.UnreadableFileException If image cannot be read.
 	 */
 	public Map<Tag, String> getImageMeta(File image, Format format, Collection<? extends Tag> tags) throws IOException {
@@ -487,13 +487,13 @@ public class ExifTool implements AutoCloseable {
 	/**
 	 * Parse image metadata.
 	 *
-	 * @param image Image.
+	 * @param image   Image.
 	 * @param options ExifTool options.
-	 * @param tags List of tags to extract.
+	 * @param tags    List of tags to extract.
 	 * @return Pair of tag associated with the value.
-	 * @throws IOException If something bad happen during I/O operations.
-	 * @throws NullPointerException If one parameter is null.
-	 * @throws IllegalArgumentException If list of tag is empty.
+	 * @throws IOException                                                  If something bad happen during I/O operations.
+	 * @throws NullPointerException                                         If one parameter is null.
+	 * @throws IllegalArgumentException                                     If list of tag is empty.
 	 * @throws com.thebuzzmedia.exiftool.exceptions.UnreadableFileException If image cannot be read.
 	 */
 	public Map<Tag, String> getImageMeta(File image, ExifToolOptions options, Collection<? extends Tag> tags) throws IOException {
@@ -527,16 +527,18 @@ public class ExifTool implements AutoCloseable {
 	}
 
 	/**
-	 * Run user's custom Exiftool command and returns raw output from Exiftool as string
-	 * This just passes the arguments to Exiftool and does not do any checking on the validity of
-	 * those arguments or validity of any image file in the argument before passing them to
-	 * Exiftool. The user is also responsible for parsing
-	 * the raw output that has been returned.
+	 * Runs a custom ExifTool command and returns raw output from ExifTool as a string.
+	 * This just passes the arguments to ExifTool and does not do any checking on the validity of
+	 * those arguments or validity of any image file in the argument.
+	 * The user is also responsible for parsing the raw output that gets returned.
+	 * <p>
+	 * <strong>NOTE:</strong> if {@code stay_open} is used then the last argument
+	 * must be {@code -execute} or ExifTool will wait forever.
 	 *
-	 * @param arguments List of strings containing the commands to pass to exiftool
-	 * @return String with whatever exiftool outputs.
-	 * @throws IOException If something bad happen during I/O operations.
-	 * @throws NullPointerException If parameter is null.
+	 * @param arguments List of strings containing the commands to pass to ExifTool
+	 * @return String with whatever ExifTool outputs.
+	 * @throws IOException          If something bad happen during I/O operations.
+	 * @throws NullPointerException If a parameter is null.
 	 */
 	public String getRawExifToolOutput(List<String> arguments) throws IOException {
 		requireNonNull(arguments, "Arguments cannot be null.");
@@ -552,7 +554,7 @@ public class ExifTool implements AutoCloseable {
 	 * Default format is numeric.
 	 *
 	 * @param image Image.
-	 * @param tags Tags to write.
+	 * @param tags  Tags to write.
 	 * @throws IOException If an error occurs during write operation.
 	 */
 	public void setImageMeta(File image, Map<? extends Tag, String> tags) throws IOException {
@@ -562,9 +564,9 @@ public class ExifTool implements AutoCloseable {
 	/**
 	 * Write image metadata in a specific format.
 	 *
-	 * @param image Image.
+	 * @param image  Image.
 	 * @param format Specified format.
-	 * @param tags Tags to write.
+	 * @param tags   Tags to write.
 	 * @throws IOException If an error occurs during write operation.
 	 */
 	public void setImageMeta(File image, Format format, Map<? extends Tag, String> tags) throws IOException {
@@ -576,9 +578,9 @@ public class ExifTool implements AutoCloseable {
 	/**
 	 * Write image metadata in a specific format.
 	 *
-	 * @param image Image.
+	 * @param image   Image.
 	 * @param options ExifTool options.
-	 * @param tags Tags to write.
+	 * @param tags    Tags to write.
 	 * @throws IOException If an error occurs during write operation.
 	 */
 	public void setImageMeta(File image, ExifToolOptions options, Map<? extends Tag, String> tags) throws IOException {

--- a/src/main/java/com/thebuzzmedia/exiftool/ExifToolBuilder.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/ExifToolBuilder.java
@@ -44,7 +44,7 @@ import static com.thebuzzmedia.exiftool.process.executor.CommandExecutors.newExe
  *
  * Set the absolute withPath to the ExifTool executable on the host system running
  * this class as defined by the `exiftool.withPath` system property.
- *
+ * <p>
  * If set, value will be used, otherwise, withPath will be read:
  * <ul>
  *   <li>
@@ -64,41 +64,41 @@ import static com.thebuzzmedia.exiftool.process.executor.CommandExecutors.newExe
  * any platform. If the ExifTool executable is named something else or not
  * in the system withPath, then this property will need to be set to point at it
  * before using this class.
- *
+ * <p>
  * On Windows be sure to double-escape the withPath to the tool,
  * for example: {@code -Dexiftool.withPath=C:\\Tools\\exiftool.exe}.
- *
+ * <p>
  * Default value is {@code exiftool}.
- *
+ * <p>
  * Relative withPath values (e.g. {@code bin/tools/exiftool}) are executed with
  * relation to the base directory the VM process was started in. Essentially
  * the directory that {@code new File(".").getAbsolutePath()} points at
  * during runtime.
  *
- * <h4>Executor</h4>
+ * <h3>Executor</h3>
  *
  * Executor is the component responsible for executing command line on the
  * system. Most of the time, the default should be fine, but if you want to tune
  * the used withExecutor, then this property is for you.
  * Custom withExecutor must implement {@link com.thebuzzmedia.exiftool.process.CommandExecutor} interface.
  *
- * <h4>Stay Open Strategy</h4>
+ * <h3>Stay Open Strategy</h3>
  *
- * ExifTool <a href="http://u88.n24.queensu.ca/exiftool/forum/index.php/topic,1402.msg12933.html#msg12933">8.36</a>
+ * ExifTool <a href="https://exiftool.org/forum/index.php?topic=1402.msg12933#msg12933">8.36</a>
  * added a new persistent-process feature that allows ExifTool to stay
  * running in a daemon mode and continue accepting commands via a file or stdin.
  * This feature is disabled by default.
- *
+ * <p>
  * <strong>NOTE:</strong> If {@code stay_open} flag is enabled, then an
  * instance of {@link com.thebuzzmedia.exiftool.exceptions.UnsupportedFeatureException}
  * may be thrown during ExifTool creation.
- *
+ * <p>
  * If this exception occurs, then you should probably:
  * <ul>
  *   <li>Update your ExifTool version.</li>
  *   <li>Create new ExifTool without this feature.</li>
- * </ul>.
- *
+ * </ul>
+ * <p>
  * <strong>Usage:</strong>
  *
  * <pre><code>
@@ -113,11 +113,11 @@ import static com.thebuzzmedia.exiftool.process.executor.CommandExecutors.newExe
  *     }
  * </code></pre>
  *
- * <h4>Custom Strategies</h4>
+ * <h3>Custom Strategies</h3>
  *
  * If default strategies are not enough, you can easily provide your own using
  * the {@link #withStrategy} method.
- *
+ * <p>
  * <strong>Usage:</strong>
  *
  * <pre><code>
@@ -192,7 +192,7 @@ public class ExifToolBuilder {
 	/**
 	 * Override default path.
 	 * Default path is defined by the environment property {@code exiftool.path} or is
-	 * set with {@code exiftool} otherwise. Setting the path explicitly will disable automatic
+	 * set to {@code exiftool} otherwise. Setting the path explicitly will disable automatic
 	 * lookup.
 	 *
 	 * @param path New path.
@@ -207,10 +207,10 @@ public class ExifToolBuilder {
 	/**
 	 * Override default path.
 	 * Default path is defined by the environment property {@code exiftool.path} or is
-	 * set with {@code exiftool} otherwise. Setting the path explicitly will disable automatic
+	 * set to {@code exiftool} otherwise. Setting the path explicitly will disable automatic
 	 * lookup.
 	 *
-	 * <br>
+	 * <p>
 	 *
 	 * <strong>Note:</strong> If path is not an executable file, a warning
 	 * will be logged but it will not fail.
@@ -230,7 +230,7 @@ public class ExifToolBuilder {
 	}
 
 	/**
-	 * Override default exifTool executor.
+	 * Override default ExifTool executor.
 	 *
 	 * @param executor New withExecutor.
 	 * @return Current builder.
@@ -260,16 +260,16 @@ public class ExifToolBuilder {
 
 	/**
 	 * Enable {@code stay_open} feature.
-	 *
+	 * <p>
 	 * <strong>Note:</strong>
 	 *
 	 * <ul>
 	 *   <li>
-	 *     If {link #withStrategy} is called, then calling this method
+	 *     If {@link #withStrategy} is called, then calling this method
 	 *     is useless.
 	 *   </li>
 	 *   <li>
-	 *     If {link #enableStayOpen(scheduler} is called, then calling this method is
+	 *     If {@link #enableStayOpen(Scheduler)} is called, then calling this method is
 	 *     useless.
 	 *   </li>
 	 * </ul>
@@ -295,7 +295,7 @@ public class ExifToolBuilder {
 
 	/**
 	 * Enable {@code stay_open} feature and perform cleanup task using given {@code scheduler}.
-	 *
+	 * <p>
 	 * <strong>Note:</strong>
 	 *
 	 * <ul>
@@ -326,7 +326,7 @@ public class ExifToolBuilder {
 
 	/**
 	 * Override default execution strategy.
-	 *
+	 * <p>
 	 * <strong>If {@link #enableStayOpen} has been called, then strategy associated with {@code stay_open} flag
 	 * will be ignored.</strong>
 	 *
@@ -353,7 +353,7 @@ public class ExifToolBuilder {
 	 *   <li>Default scheduler instances will be used with a delay of {@code cleanupDelay}.</li>
 	 * </ul>
 	 *
-	 * @param poolSize Pool size.
+	 * @param poolSize     Pool size.
 	 * @param cleanupDelay Cleanup delay for each scheduler of pool elements.
 	 * @return Current builder.
 	 */
@@ -399,7 +399,7 @@ public class ExifToolBuilder {
 	/**
 	 * Create exiftool instance with previous settings.
 	 *
-	 * @return Exiftool instance.
+	 * @return ExifTool instance.
 	 */
 	public ExifTool build() {
 		String path = firstNonNull(this.path, PATH);
@@ -425,8 +425,8 @@ public class ExifToolBuilder {
 	 * <li>Otherwise, result of function is returned.</li>
 	 * </ul>
 	 *
-	 * @param value First value.
-	 * @param factory Function used to get non null value.
+	 * @param value   First value.
+	 * @param factory Function used to get non-null value.
 	 * @param <T> Type of values.
 	 * @return Non null value.
 	 */
@@ -448,14 +448,14 @@ public class ExifToolBuilder {
 	/**
 	 * Return the absolute path to the ExifTool executable on the host system running
 	 * this class as defined by the {@code exiftool.path} system property.
-	 *
+	 * <p>
 	 * This system property can be set on startup with {@code -Dexiftool.path=/path/to/exiftool}
 	 * or by calling {@link System#setProperty(String, String)} before
 	 * this class is loaded.
-	 *
+	 * <p>
 	 * On Windows be sure to double-escape the path to the tool,
 	 * for example: {@code -Dexiftool.path=C:\\Tools\\exiftool.exe}.
-	 *
+	 * <p>
 	 * Default value is {@code exiftool}.
 	 */
 	private static class PathFunction implements FactoryFunction<String> {
@@ -470,25 +470,25 @@ public class ExifToolBuilder {
 	 * up and cleans up the daemon ExifTool process and the read/write streams
 	 * used to communicate with it when the {@code stay_open} feature is
 	 * used.
-	 *
-	 * Ever time a call to {@link ExifTool#getImageMeta} is processed, the timer
+	 * <p>
+	 * Every time a call to {@link ExifTool#getImageMeta} is processed, the timer
 	 * keeping track of cleanup is reset; more specifically, this class has to
 	 * experience no activity for this duration of time before the cleanup
 	 * process is fired up and cleans up the host OS process and the stream
 	 * resources.
-	 *
+	 * <p>
 	 * Any subsequent calls to {@link ExifTool#getImageMeta} after a cleanup simply
 	 * re-initializes the resources.
-	 *
+	 * <p>
 	 * This system property can be set on startup with {@code -Dexiftool.processCleanupDelay=600000}
 	 * or by calling {@link System#setProperty(String, String)} before
 	 * this class is loaded.
-	 *
+	 * <p>
 	 * Setting this value to 0 disables the automatic cleanup thread completely
-	 * and the caller will need to manually cleanup the external ExifTool
+	 * and the caller will need to manually clean up the external ExifTool
 	 * process and read/write streams by calling {@link ExifTool#close} method.
-	 *
-	 * Default value is {@code 600, 000} (10 minutes).
+	 * <p>
+	 * Default value is {@code 600000} (10 minutes).
 	 */
 	private static class DelayFunction implements FactoryFunction<Long> {
 		@Override
@@ -498,7 +498,7 @@ public class ExifToolBuilder {
 	}
 
 	/**
-	 * Returns the default executor for the created exifTool instance.
+	 * Returns the default executor for the created ExifTool instance.
 	 * Default executor is the result of {@link CommandExecutors#newExecutor()} method.
 	 */
 	private static class ExecutorFunction implements FactoryFunction<CommandExecutor> {
@@ -540,7 +540,7 @@ public class ExifToolBuilder {
 	 * By default, a really simple strategy is used (instance of {@link DefaultStrategy}).
 	 *
 	 * <h3>StayOpen</h3>
-	 * If the {@code stay_open} has been enabled, then an instance of {@link StayOpenStrategy}
+	 * If {@code stay_open} has been enabled, then an instance of {@link StayOpenStrategy}
 	 * will be created. For this strategy, a scheduler will be created. This scheduler will be used to run
 	 * a task to clean resources used by this strategy. This task will run automatically after a specified
 	 * delay.

--- a/src/main/java/com/thebuzzmedia/exiftool/ExifToolBuilder.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/ExifToolBuilder.java
@@ -30,9 +30,9 @@ import com.thebuzzmedia.exiftool.process.executor.CommandExecutors;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import static com.thebuzzmedia.exiftool.core.schedulers.SchedulerDuration.millis;
-import static com.thebuzzmedia.exiftool.process.executor.CommandExecutors.newExecutor;
 
 /**
  * Builder for {@link ExifTool} instance.
@@ -134,19 +134,56 @@ public class ExifToolBuilder {
 	private static final Logger log = LoggerFactory.getLogger(ExifToolBuilder.class);
 
 	/**
-	 * Function to get default path value.
+	 * Gets the default path value.
+	 * <p>
+	 * The path value is the absolute path to the ExifTool executable on the host system running
+	 * this class as defined by the {@code exiftool.path} system property.
+	 * <p>
+	 * This system property can be set on startup with {@code -Dexiftool.path=/path/to/exiftool}
+	 * or by calling {@link System#setProperty(String, String)} before
+	 * this class is loaded.
+	 * <p>
+	 * On Windows be sure to double-escape the path to the tool,
+	 * for example: {@code -Dexiftool.path=C:\\Tools\\exiftool.exe}.
+	 * <p>
+	 * If the property is not defined it will use {@code exiftool}.
 	 */
-	private static final PathFunction PATH = new PathFunction();
+	private static final Supplier<String> PATH = () -> System.getProperty("exiftool.path", "exiftool");
 
 	/**
-	 * Function to get default cleanup interval.
+	 * Gets the default cleanup interval.
+	 * <p>
+	 * The cleanup interval is the interval (in milliseconds) of inactivity before the cleanup thread wakes
+	 * up and cleans up the daemon ExifTool process and the read/write streams
+	 * used to communicate with it when the {@code stay_open} feature is
+	 * used.
+	 * <p>
+	 * Every time a call to {@link ExifTool#getImageMeta} is processed, the timer
+	 * keeping track of cleanup is reset; more specifically, this class has to
+	 * experience no activity for this duration of time before the cleanup
+	 * process is fired up and cleans up the host OS process and the stream
+	 * resources.
+	 * <p>
+	 * Any subsequent calls to {@link ExifTool#getImageMeta} after a cleanup simply
+	 * re-initializes the resources.
+	 * <p>
+	 * This system property can be set on startup with {@code -Dexiftool.processCleanupDelay=600000}
+	 * or by calling {@link System#setProperty(String, String)} before
+	 * this class is loaded.
+	 * <p>
+	 * Setting this value to 0 disables the automatic cleanup thread completely
+	 * and the caller will need to manually clean up the external ExifTool
+	 * process and read/write streams by calling {@link ExifTool#close} method.
+	 * <p>
+	 * If the property is not defined it will default to {@code 600000} (10 minutes).
 	 */
-	private static final DelayFunction DELAY = new DelayFunction();
+	private static final Supplier<Long> DELAY = () -> Long.getLong("exiftool.processCleanupDelay", 600000);
 
 	/**
-	 * Function to get default executor environment.
+	 * Gets the default executor for the created ExifTool instance.
+	 * The default executor is the result of {@link CommandExecutors#newExecutor()} method.
 	 */
-	private static final ExecutorFunction EXECUTOR = new ExecutorFunction();
+	private static final Supplier<CommandExecutor> EXECUTOR = CommandExecutors::newExecutor;
 
 	/**
 	 * ExifTool path.
@@ -426,86 +463,12 @@ public class ExifToolBuilder {
 	 * </ul>
 	 *
 	 * @param value   First value.
-	 * @param factory Function used to get non-null value.
+	 * @param supplier Function used to get non-null value.
 	 * @param <T> Type of values.
 	 * @return Non null value.
 	 */
-	private static <T> T firstNonNull(T value, FactoryFunction<T> factory) {
-		return value == null ? factory.apply() : value;
-	}
-
-	/**
-	 * Interface to return values.
-	 * This interface should be used by builder to lazily create
-	 * default settings parameters.
-	 *
-	 * @param <T> Type of settings.
-	 */
-	private interface FactoryFunction<T> {
-		T apply();
-	}
-
-	/**
-	 * Return the absolute path to the ExifTool executable on the host system running
-	 * this class as defined by the {@code exiftool.path} system property.
-	 * <p>
-	 * This system property can be set on startup with {@code -Dexiftool.path=/path/to/exiftool}
-	 * or by calling {@link System#setProperty(String, String)} before
-	 * this class is loaded.
-	 * <p>
-	 * On Windows be sure to double-escape the path to the tool,
-	 * for example: {@code -Dexiftool.path=C:\\Tools\\exiftool.exe}.
-	 * <p>
-	 * Default value is {@code exiftool}.
-	 */
-	private static class PathFunction implements FactoryFunction<String> {
-		@Override
-		public String apply() {
-			return System.getProperty("exiftool.path", "exiftool");
-		}
-	}
-
-	/**
-	 * Return the interval (in milliseconds) of inactivity before the cleanup thread wakes
-	 * up and cleans up the daemon ExifTool process and the read/write streams
-	 * used to communicate with it when the {@code stay_open} feature is
-	 * used.
-	 * <p>
-	 * Every time a call to {@link ExifTool#getImageMeta} is processed, the timer
-	 * keeping track of cleanup is reset; more specifically, this class has to
-	 * experience no activity for this duration of time before the cleanup
-	 * process is fired up and cleans up the host OS process and the stream
-	 * resources.
-	 * <p>
-	 * Any subsequent calls to {@link ExifTool#getImageMeta} after a cleanup simply
-	 * re-initializes the resources.
-	 * <p>
-	 * This system property can be set on startup with {@code -Dexiftool.processCleanupDelay=600000}
-	 * or by calling {@link System#setProperty(String, String)} before
-	 * this class is loaded.
-	 * <p>
-	 * Setting this value to 0 disables the automatic cleanup thread completely
-	 * and the caller will need to manually clean up the external ExifTool
-	 * process and read/write streams by calling {@link ExifTool#close} method.
-	 * <p>
-	 * Default value is {@code 600000} (10 minutes).
-	 */
-	private static class DelayFunction implements FactoryFunction<Long> {
-		@Override
-		public Long apply() {
-			return Long.getLong("exiftool.processCleanupDelay", 600000);
-		}
-	}
-
-	/**
-	 * Returns the default executor for the created ExifTool instance.
-	 * Default executor is the result of {@link CommandExecutors#newExecutor()} method.
-	 */
-	private static class ExecutorFunction implements FactoryFunction<CommandExecutor> {
-		@Override
-		public CommandExecutor apply() {
-			return newExecutor();
-		}
+	private static <T> T firstNonNull(T value, Supplier<T> supplier) {
+		return value == null ? supplier.get() : value;
 	}
 
 	/**
@@ -516,7 +479,7 @@ public class ExifToolBuilder {
 	 * <li>If {@code delay} is greater than zero, then an instance of {@link DefaultScheduler} will be returned.</li>
 	 * </ul>
 	 */
-	private static class SchedulerFunction implements FactoryFunction<Scheduler> {
+	private static class SchedulerFunction implements Supplier<Scheduler> {
 		private final Long delay;
 
 		public SchedulerFunction(Long delay) {
@@ -524,7 +487,7 @@ public class ExifToolBuilder {
 		}
 
 		@Override
-		public Scheduler apply() {
+		public Scheduler get() {
 			// Otherwise, this is the StayOpen strategy.
 			// We have to look up the delay between automatic clean and create
 			// the scheduler.
@@ -545,7 +508,7 @@ public class ExifToolBuilder {
 	 * a task to clean resources used by this strategy. This task will run automatically after a specified
 	 * delay.
 	 */
-	private static class StrategyFunction implements FactoryFunction<ExecutionStrategy> {
+	private static class StrategyFunction implements Supplier<ExecutionStrategy> {
 		private final Boolean stayOpen;
 
 		private final Long delay;
@@ -562,12 +525,12 @@ public class ExifToolBuilder {
 		}
 
 		@Override
-		public ExecutionStrategy apply() {
+		public ExecutionStrategy get() {
 			// First, try the pool strategy.
 			if (poolSize > 0) {
 				List<ExecutionStrategy> strategies = new ArrayList<>(poolSize);
 				for (int i = 0; i < poolSize; i++) {
-					Scheduler scheduler = new SchedulerFunction(delay).apply();
+					Scheduler scheduler = new SchedulerFunction(delay).get();
 					StayOpenStrategy strategy = new StayOpenStrategy(scheduler);
 					strategies.add(strategy);
 				}

--- a/src/main/java/com/thebuzzmedia/exiftool/Format.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/Format.java
@@ -24,14 +24,12 @@ import java.util.List;
  * For instance, default implementations defined by {@link com.thebuzzmedia.exiftool.core.StandardFormat}
  * values can be returned in: numeric or human-readable text.
  *
- * <br>
+ * <p>
  *
  * ExifTool, via the {@code -n} command line arg, is capable of
  * returning most values in their raw numeric form (e.g.
  * Aperture="2.8010323841") as well as a more human-readable/friendly format
  * (e.g. Aperture="2.8").
- *
- * <br>
  *
  * @author Riyad Kalla (software@thebuzzmedia.com)
  * @author Mickael Jeanroy

--- a/src/main/java/com/thebuzzmedia/exiftool/Scheduler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/Scheduler.java
@@ -19,7 +19,7 @@ package com.thebuzzmedia.exiftool;
 
 /**
  * Scheduler interface.
- *
+ * <p>
  * Each implementation should provide implementation for:
  * <ul>
  *   <li>{@link #start(Runnable)} method: should schedule task in a specified amount of time.</li>

--- a/src/main/java/com/thebuzzmedia/exiftool/Tag.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/Tag.java
@@ -21,14 +21,14 @@ package com.thebuzzmedia.exiftool;
  * A {@link Tag} is a value that can be easily extracted from images with
  * an external install of ExifTool.
  *
- * <br>
+ * <p>
  *
  * A tag that can be easily parsed to a valid value
  * using the {@link #parse(String)} hint from each {@link Tag}.
- * Using this method allow anyone to convert a string value to the correct
+ * Using this method allows anyone to convert a string value to the correct
  * data format.
  *
- * <br>
+ * <p>
  *
  * Implementations should not make an attempt at converting the value automatically
  * in case the caller decides they would prefer tag values returned in
@@ -39,10 +39,10 @@ package com.thebuzzmedia.exiftool;
  * the caller decides they want to parse them is a safer and more robust
  * approach.
  *
- * <br>
+ * <p>
  *
  * The types provided by each tag are merely a hint based on the
- * <a href="http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/index.html">ExifTool Tag Guide</a>
+ * <a href="https://exiftool.org/TagNames/index.html">ExifTool Tag Guide</a>
  * by Phil Harvey; the caller is free to parse or process the returned {@link String} values
  * any way they wish.
  *
@@ -63,7 +63,7 @@ public interface Tag {
 	/**
 	 * Used to get the display name of the tag, which is the actual name printed
 	 * by the tool on stout. 
-	 *
+	 * <p>
 	 * For simple tags this is equivalent to value returned by <code>getName</code>.
 	 *
 	 * @since 2.4.0

--- a/src/main/java/com/thebuzzmedia/exiftool/Version.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/Version.java
@@ -51,10 +51,10 @@ public final class Version implements Comparable<Version> {
 	/**
 	 * Create new version number from a given string formatted
 	 * such as: {@code [major].[minor].[patch]}.
-	 *
+	 * <p>
 	 * Major identifier is mandatory, other elements are optional and will be initialized
 	 * to zero by default.
-	 *
+	 * <p>
 	 * Valid format: 1.1.0 / 1.1 / 1
 	 *
 	 * @param version Version number.

--- a/src/main/java/com/thebuzzmedia/exiftool/VersionCache.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/VersionCache.java
@@ -35,7 +35,7 @@ public interface VersionCache {
 	Version load(String exifTool, CommandExecutor executor);
 
 	/**
-	 * Get current size of cache (a.k.a number of entries).
+	 * Get current size of cache (a.k.a. number of entries).
 	 *
 	 * @return Cache Size.
 	 */

--- a/src/main/java/com/thebuzzmedia/exiftool/commons/gc/JdkCleaner.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/commons/gc/JdkCleaner.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of {@link Cleaner} using {@code java.lang.ref.Cleaner} implementation.
- *
+ * <p>
  * This cleaner is created using reflection, once this library will support Java >= 9 only, we'll be
  * able to get rid of Reflection.
  */

--- a/src/main/java/com/thebuzzmedia/exiftool/commons/gc/UnsafeCleaner.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/commons/gc/UnsafeCleaner.java
@@ -26,7 +26,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of {@link Cleaner} using {@code sun.misc.Cleaner} implementation.
- *
+ * <p>
  * This cleaner is created using reflection, as {@code sun.misc.Cleaner} does not exist in Java >= 9.
  * Once this library will support java >= 9 only, this implementation will be removed.
  */

--- a/src/main/java/com/thebuzzmedia/exiftool/commons/io/IOs.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/commons/io/IOs.java
@@ -74,7 +74,7 @@ public final class IOs {
 			throw ex;
 		}
 		finally {
-			// Maybe last line is not null (suppose an handler that should stop on given output).
+			// Maybe last line is not null (suppose a handler that should stop on given output).
 			// On the opposite, if line is null, then we know that stream should be closed.
 			if (line == null) {
 				closeQuietly(br);

--- a/src/main/java/com/thebuzzmedia/exiftool/commons/io/IOs.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/commons/io/IOs.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Static Input/Output Utilities.
@@ -40,7 +41,7 @@ public final class IOs {
 	/**
 	 * Encoding.
 	 */
-	private static final Charset UTF_8 = Charset.forName("UTF-8");
+	private static final Charset UTF_8 = StandardCharsets.UTF_8;
 
 	// Ensure non instantiation.
 	private IOs() {

--- a/src/main/java/com/thebuzzmedia/exiftool/commons/lang/Objects.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/commons/lang/Objects.java
@@ -27,13 +27,13 @@ public final class Objects {
 	}
 
 	/**
-	 * Returns the first of two given parameters that is not {@code null}.
+	 * Returns the first parameter that is not {@code null}.
 	 *
 	 * @param val1 First value.
 	 * @param val2 Second value.
-	 * @param others Other value.
+	 * @param others Other values.
 	 * @param <T> Type of parameters.
-	 * @return First parameter if it is not {@code null}, second parameter otherwise.
+	 * @return The first non {@code null} parameter.
 	 */
 	@SafeVarargs
 	public static <T> T firstNonNull(T val1, T val2, T... others) {

--- a/src/main/java/com/thebuzzmedia/exiftool/commons/lang/PreConditions.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/commons/lang/PreConditions.java
@@ -39,7 +39,7 @@ public final class PreConditions {
 	 * <ul>
 	 *   <li>Not {@code null}.</li>
 	 *   <li>Not empty.</li>
-	 *   <li>Not blank (i.e contains at least one character other than space).</li>
+	 *   <li>Not blank (i.e. contains at least one character other than space).</li>
 	 * </ul>
 	 *
 	 * @param val     Value to check.
@@ -58,7 +58,7 @@ public final class PreConditions {
 	}
 
 	/**
-	 * Ensures that array is:
+	 * Ensures that an array is:
 	 * <ul>
 	 *   <li>Not {@code null}.</li>
 	 *   <li>Not empty.</li>
@@ -81,7 +81,7 @@ public final class PreConditions {
 	}
 
 	/**
-	 * Ensures that map is:
+	 * Ensures that a map is:
 	 * <ul>
 	 *   <li>Not {@code null}.</li>
 	 *   <li>Not empty.</li>
@@ -105,7 +105,7 @@ public final class PreConditions {
 	}
 
 	/**
-	 * Ensures that iterable element is:
+	 * Ensures that an iterable element is:
 	 * <ul>
 	 *   <li>Not {@code null}.</li>
 	 *   <li>Not empty.</li>
@@ -129,7 +129,7 @@ public final class PreConditions {
 	}
 
 	/**
-	 * Check if given number is strictly positive (strictly greater than zero).
+	 * Checks if the given number is strictly positive (strictly greater than zero).
 	 *
 	 * @param nb      Number.
 	 * @param message Error message.
@@ -148,7 +148,7 @@ public final class PreConditions {
 	}
 
 	/**
-	 * Check that a given file exist and is readable.
+	 * Checks that a given file exist and is readable.
 	 *
 	 * @param file    File to check.
 	 * @param message Error message.
@@ -167,7 +167,7 @@ public final class PreConditions {
 	}
 
 	/**
-	 * Check that a given file exist and is writable.
+	 * Checks that a given file exist and is writable.
 	 *
 	 * @param file    File to check.
 	 * @param message Error message.

--- a/src/main/java/com/thebuzzmedia/exiftool/commons/lang/PreConditions.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/commons/lang/PreConditions.java
@@ -23,7 +23,6 @@ import com.thebuzzmedia.exiftool.exceptions.UnwritableFileException;
 import java.io.File;
 import java.util.Map;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -51,7 +50,7 @@ public final class PreConditions {
 	 */
 	public static String notBlank(String val, String message) {
 		requireNonNull(val, message);
-		if (val.length() == 0 || val.trim().length() == 0) {
+		if (val.isEmpty() || val.trim().isEmpty()) {
 			throw new IllegalArgumentException(message);
 		}
 
@@ -98,7 +97,7 @@ public final class PreConditions {
 	 */
 	public static <T, U> Map<T, U> notEmpty(Map<T, U> val, String message) {
 		requireNonNull(val, message);
-		if (val.size() == 0) {
+		if (val.isEmpty()) {
 			throw new IllegalArgumentException(message);
 		}
 
@@ -184,9 +183,5 @@ public final class PreConditions {
 		}
 
 		return file;
-	}
-
-	private static String errorMessage(String message, Object[] params) {
-		return params.length > 0 ? format(message, params) : message;
 	}
 }

--- a/src/main/java/com/thebuzzmedia/exiftool/commons/lang/Strings.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/commons/lang/Strings.java
@@ -29,15 +29,14 @@ public final class Strings {
 	}
 
 	/**
-	 * Check that given string is not {@code null} or empty.
+	 * Checks that the given string is not {@code null} or empty.
 	 *
 	 * @param value Given string to check.
-	 * @return {@code true} if {@code value} is {@code null} or empty.
+	 * @return {@code true} if {@code value} is not {@code null} nor empty.
 	 */
 	public static boolean isNotEmpty(String value) {
 		return value != null && !value.isEmpty();
 	}
-
 
 	/**
 	 * Try to parse a string as an Integer and return the value if valid, or an Optional empty if not.

--- a/src/main/java/com/thebuzzmedia/exiftool/commons/reflection/ClassUtils.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/commons/reflection/ClassUtils.java
@@ -31,11 +31,11 @@ public final class ClassUtils {
 	}
 
 	/**
-	 * Get given class if available on classpath, otherwise throw {@link ReflectionException}.
+	 * Get the given class if available on classpath, otherwise throw {@link ReflectionException}.
 	 *
 	 * @param klass Class name.
 	 * @return The class instance if available.
-	 * @throws ReflectionException If given class is not found in the classpath.
+	 * @throws ReflectionException If the given class is not found in the classpath.
 	 */
 	public static Class<?> lookupClass(String klass) {
 		try {
@@ -47,11 +47,11 @@ public final class ClassUtils {
 	}
 
 	/**
-	 * Find static method with given return type parameter types on given class.
+	 * Find static method with given return type and parameter types on given class.
 	 *
-	 * @param klass The class.
-	 * @param methodName The method name.
-	 * @param returnType The method return type.
+	 * @param klass          The class.
+	 * @param methodName     The method name.
+	 * @param returnType     The method return type.
 	 * @param parameterTypes Parameter types.
 	 * @return The method.
 	 * @throws ReflectionException If given method does not exist.
@@ -70,11 +70,11 @@ public final class ClassUtils {
 	}
 
 	/**
-	 * Find non static method with given return type parameter types on given class.
+	 * Find non-static method with given return type parameter types on given class.
 	 *
-	 * @param klass The class.
-	 * @param methodName The method name.
-	 * @param returnType The method return type.
+	 * @param klass          The class.
+	 * @param methodName     The method name.
+	 * @param returnType     The method return type.
 	 * @param parameterTypes Parameter types.
 	 * @return The method.
 	 * @throws ReflectionException If given method does not exist.
@@ -96,7 +96,7 @@ public final class ClassUtils {
 	 * Invoke given static method.
 	 *
 	 * @param method The method to invoke.
-	 * @param args Method parameters.
+	 * @param args   Method parameters.
 	 * @return The method result.
 	 * @throws ReflectionException If an error occurs while calling method.
 	 */
@@ -109,7 +109,7 @@ public final class ClassUtils {
 	 *
 	 * @param method The method to invoke.
 	 * @param target The target instance.
-	 * @param args Method parameters.
+	 * @param args   Method parameters.
 	 * @return The method result.
 	 * @throws ReflectionException If an error occurs while calling method.
 	 */
@@ -121,7 +121,7 @@ public final class ClassUtils {
 	 * Invoke given method with given arguments.
 	 *
 	 * @param method The method to invoke.
-	 * @param args Method parameters.
+	 * @param args   Method parameters.
 	 * @return The method result.
 	 * @throws ReflectionException If an error occurs while calling method.
 	 */

--- a/src/main/java/com/thebuzzmedia/exiftool/core/NonConvertedTag.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/NonConvertedTag.java
@@ -25,11 +25,11 @@ import java.util.Objects;
 
 /**
  * Utility class used to generate tags which are not print converted. This is
- * done in Exiftool by suffixing <code>#</code> to the tag and it has the same
- * effect of <code>-n</code> but applied on a per-tag basis.
- *
+ * done in ExifTool by suffixing {@code #} to the tag and it has the same
+ * effect of {@code -n} but applied on a per-tag basis.
+ * <p>
  * The class wraps another tag and manages its different query name. By design
- * <code>NonConvertedTag.of(Tag.ANY)</code> is not equal to <code>Tag.ANY</code>
+ * {@code NonConvertedTag.of(Tag.ANY)} is not equal to {@code Tag.ANY}
  * since it's possible to query two different formats of the same tag.
  *
  * @author Jack (jack@pixbits.com)

--- a/src/main/java/com/thebuzzmedia/exiftool/core/StandardFormat.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/StandardFormat.java
@@ -30,28 +30,28 @@ import static java.util.Collections.singletonList;
  * Enum used to define the 2 different output formats that {@link StandardTag}
  * values can be returned in: numeric or human-readable text.
  *
- * <br>
+ * <p>
  *
- * ExifTool, via the <code>-n</code> command line arg, is capable of returning
+ * ExifTool, via the {@code -n} command line arg, is capable of returning
  * most values in their raw numeric form (e.g. Aperture="2.8010323841") as well
  * as a more human-readable/friendly format (e.g. Aperture="2.8").
  *
- * <br>
+ * <p>
  *
  * If the caller finds the human-readable format easier to process,
  * {@link StandardFormat#HUMAN_READABLE} can be specified when calling
  * {@link com.thebuzzmedia.exiftool.ExifTool#getImageMeta(File, Format, Collection)}
  * and the returned {@link String} values processed manually by the caller.
  *
- * <br>
+ * <p>
  *
  * In order to see the types of values that are returned when
  * {@link StandardFormat#HUMAN_READABLE} is used, you can check the
  * comprehensive
- * <a href="http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/index.html">
+ * <a href="https://exiftool.org/TagNames/index.html">
  * ExifTool Tag Guide</a>.
  *
- * <br>
+ * <p>
  *
  * This makes sense with some values like Aperture that in
  * {@link StandardFormat#NUMERIC} format end up returning as 14-decimal-place,

--- a/src/main/java/com/thebuzzmedia/exiftool/core/StandardOptions.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/StandardOptions.java
@@ -36,7 +36,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableSet;
 
 /**
- * Support options from exiftool binary. Most options are documented
+ * Support options from ExifTool binary. Most options are documented
  * here: <a href="https://linux.die.net/man/1/exiftool">https://linux.die.net/man/1/exiftool</a>.
  */
 public final class StandardOptions implements ExifToolOptions {
@@ -113,7 +113,7 @@ public final class StandardOptions implements ExifToolOptions {
 
 	/**
 	 * Set current language for tag descriptions and converted values. LANG is "de", "fr", "ja", etc.
-	 *
+	 * <p>
 	 * Note that tag/group names are always English, independent of the lang setting,
 	 * and translation of warning/error messages has not yet been implemented.
 	 */
@@ -139,9 +139,9 @@ public final class StandardOptions implements ExifToolOptions {
 	private final boolean extractUnknown;
 
 	/**
-	 * Wether or not to override original file when writing information to an image. Caution: This option should only
+	 * Whether to override original file when writing information to an image. Caution: This option should only
 	 * be used if you already have separate backup copies of your image files.
-	 *
+	 * <p>
 	 * Two mode are available:
 	 * <ul>
 	 *   <li>
@@ -149,7 +149,7 @@ public final class StandardOptions implements ExifToolOptions {
 	 *     edited version in a single operation.
 	 *   </li>
 	 *   <li>
-	 *     Similar to -overwrite_original except that an extra step is added to allow the original file attributes to be preserved.
+	 *     Similar to {@code -overwrite_original} except that an extra step is added to allow the original file attributes to be preserved.
 	 *     For example, on a Mac this causes the original file creation date, ownership, type, creator, label color and icon to be preserved.
 	 *     This is implemented by opening the original file in update mode and replacing its data with a copy of a temporary file before
 	 *     deleting the temporary. The extra step results in slower performance, so the first mode should be used instead unless necessary.
@@ -159,7 +159,7 @@ public final class StandardOptions implements ExifToolOptions {
 	private final OverwriteMode overwriteOriginal;
 
 	/**
-	 * Output information in the form of exiftool arguments, suitable for use with the -@ option when writing.
+	 * Output information in the form of exiftool arguments, suitable for use with the {@code -@} option when writing.
 	 */
 	private final boolean useArgsFormat;
 

--- a/src/main/java/com/thebuzzmedia/exiftool/core/StandardTag.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/StandardTag.java
@@ -27,17 +27,17 @@ import java.util.regex.Pattern;
  * Enum used to pre-define a convenient list of tags that can be easily
  * extracted from images using this class with an external install of
  * ExifTool.
- *
+ * <p>
  * Each tag defined also includes a type hint for the parsed value
  * associated with it when the default {@link com.thebuzzmedia.exiftool.core.StandardFormat#NUMERIC}
  * value format is used.
  *
- * <br>
+ * <p>
  *
  * The types provided by each tag are merely a hint based on the
- * <a href="http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/index.html">ExifTool Tag Guide</a>
+ * <a href="https://exiftool.org/TagNames/index.html">ExifTool Tag Guide</a>
  * by Phil Harvey; the caller is free to parse or process the returned {@link String} values any way they wish.
- *
+ * <p>
  * This list was determined by looking at the common metadata tag values
  * written to images by popular mobile devices (iPhone, Android) as well as
  * cameras like simple point and shoots as well as DSLRs. As an additional

--- a/src/main/java/com/thebuzzmedia/exiftool/core/UnspecifiedTag.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/UnspecifiedTag.java
@@ -31,12 +31,11 @@ import static com.thebuzzmedia.exiftool.Constants.SEPARATOR;
  * <p>
  * Since the type of value is unknown, typed parsing is not possible,
  * and the tag does not know whether multiple values are expected or not.
- * Consequently, when parsing, it returns a String[] regardless of whether
+ * Consequently, when parsing, it returns a {@code String[]} regardless of whether
  * the tag will ever have multiple values. Further parsing is then up to the caller.
  *
  * @author David Edwards (david@more.fool.me.uk)
  */
-
 public final class UnspecifiedTag implements Tag {
 
 	/**

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/RawOutputHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/RawOutputHandler.java
@@ -31,7 +31,7 @@ public class RawOutputHandler implements OutputHandler {
 	}
 
 	public String getOutput() {
-		// output the raw string that exiftool outputes
+		// output the raw string that exiftool outputs
 		return output.toString();
 	}
 }

--- a/src/main/java/com/thebuzzmedia/exiftool/core/handlers/StopHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/handlers/StopHandler.java
@@ -21,7 +21,7 @@ import com.thebuzzmedia.exiftool.process.OutputHandler;
 
 /**
  * Check if line means it is the end of the stream.
- *
+ * <p>
  * End is detected if:
  * <ul>
  *   <li>Line is {@code null}.</li>

--- a/src/main/java/com/thebuzzmedia/exiftool/core/schedulers/NoOpScheduler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/schedulers/NoOpScheduler.java
@@ -20,7 +20,7 @@ package com.thebuzzmedia.exiftool.core.schedulers;
 import com.thebuzzmedia.exiftool.Scheduler;
 
 /**
- * This scheduler do nothing (use it for disabling scheduler).
+ * This scheduler does nothing (use it for disabling scheduler).
  */
 public class NoOpScheduler implements Scheduler {
 

--- a/src/main/java/com/thebuzzmedia/exiftool/core/schedulers/SchedulerDuration.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/schedulers/SchedulerDuration.java
@@ -53,7 +53,7 @@ public final class SchedulerDuration {
 	/**
 	 * Create new duration in millis.
 	 *
-	 * @param delay The delay, in millis.
+	 * @param delay    The delay, in millis.
 	 * @param timeUnit The time unit.
 	 * @return The duration.
 	 */
@@ -74,7 +74,7 @@ public final class SchedulerDuration {
 	/**
 	 * Create new duration.
 	 *
-	 * @param delay Duration delay.
+	 * @param delay    Duration delay.
 	 * @param timeUnit Duration unit.
 	 */
 	private SchedulerDuration(long delay, TimeUnit timeUnit) {

--- a/src/main/java/com/thebuzzmedia/exiftool/core/schedulers/TimerScheduler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/schedulers/TimerScheduler.java
@@ -54,14 +54,14 @@ public class TimerScheduler implements Scheduler {
 
 	/**
 	 * Pending task.
-	 * This task should be cancel with {@link #stop()} method before any
+	 * This task should be cancelled with {@link #stop()} method before any
 	 * call to {@link #start(Runnable)} method.
 	 */
 	private TimerTask pendingTask;
 
 	/**
 	 * Create scheduler.
-	 * @param name Thread name.
+	 * @param name  Thread name.
 	 * @param delay Delay before task execution.
 	 * @throws IllegalArgumentException If {@code delay} is not strictly positive.
 	 */

--- a/src/main/java/com/thebuzzmedia/exiftool/core/strategies/PoolStrategy.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/strategies/PoolStrategy.java
@@ -171,6 +171,7 @@ public class PoolStrategy implements ExecutionStrategy {
 		}
 	}
 
+	@FunctionalInterface
 	private interface ExecutionStrategyFunction {
 		void apply(ExecutionStrategy strategy, int i) throws Exception;
 	}

--- a/src/main/java/com/thebuzzmedia/exiftool/core/strategies/PoolStrategy.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/strategies/PoolStrategy.java
@@ -37,11 +37,11 @@ import static com.thebuzzmedia.exiftool.commons.lang.PreConditions.notEmpty;
 /**
  * Implementation of {@link ExecutionStrategy} using a pool of
  * strategies.
- *
- * Each time {{@link #execute(CommandExecutor, String, List, OutputHandler)} method
+ * <p>
+ * Each time {@link #execute(CommandExecutor, String, List, OutputHandler)} method
  * is called, an internal strategy from the pool is picked and return to the pool once work
  * is finished.
- *
+ * <p>
  * This strategy should be used in a multithreaded environment, when application need to
  * extract exif data from images in parallel.
  */
@@ -53,7 +53,7 @@ public class PoolStrategy implements ExecutionStrategy {
 	private static final Logger log = LoggerFactory.getLogger(PoolStrategy.class);
 
 	/**
-	 * Pool size (i.e number of available slot).
+	 * Pool size (i.e. number of available slot).
 	 */
 	private final int poolSize;
 

--- a/src/main/java/com/thebuzzmedia/exiftool/core/strategies/PoolStrategy.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/core/strategies/PoolStrategy.java
@@ -166,7 +166,7 @@ public class PoolStrategy implements ExecutionStrategy {
 			}
 		}
 
-		if (thrownEx.size() > 0) {
+		if (!thrownEx.isEmpty()) {
 			throw new PoolIOException("Some strategies in the pool failed to close properly", thrownEx);
 		}
 	}

--- a/src/main/java/com/thebuzzmedia/exiftool/exceptions/ExifToolNotFoundException.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/exceptions/ExifToolNotFoundException.java
@@ -39,7 +39,7 @@ public class ExifToolNotFoundException extends AbstractExifException {
 	/**
 	 * Create exception.
 	 *
-	 * @param path ExifTool path defined during command execution.
+	 * @param path   ExifTool path defined during command execution.
 	 * @param result The result triggered during command execution.
 	 */
 	public ExifToolNotFoundException(String path, CommandResult result) {
@@ -51,7 +51,7 @@ public class ExifToolNotFoundException extends AbstractExifException {
 	/**
 	 * Create exception.
 	 *
-	 * @param ex The original exception.
+	 * @param ex   The original exception.
 	 * @param path ExifTool path defined during command execution.
 	 */
 	public ExifToolNotFoundException(IOException ex, String path) {

--- a/src/main/java/com/thebuzzmedia/exiftool/exceptions/PoolIOException.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/exceptions/PoolIOException.java
@@ -36,7 +36,7 @@ public class PoolIOException extends IOException {
 	/**
 	 * Create exception.
 	 *
-	 * @param message Error message.
+	 * @param message          Error message.
 	 * @param thrownExceptions Original exceptions.
 	 */
 	public PoolIOException(String message, Collection<Exception> thrownExceptions) {

--- a/src/main/java/com/thebuzzmedia/exiftool/exceptions/UnreadableFileException.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/exceptions/UnreadableFileException.java
@@ -22,8 +22,10 @@ import java.io.File;
 /**
  * Exception thrown when a file cannot be read.
  * A file cannot be read because:
- * - It does not exist.
- * - It is corrupted and cannot be read.
+ * <ul>
+ *   <li>It does not exist.</li>
+ *   <li>It is corrupted and cannot be read.</li>
+ * </ul>
  */
 public class UnreadableFileException extends AbstractExifException {
 
@@ -35,7 +37,7 @@ public class UnreadableFileException extends AbstractExifException {
 	/**
 	 * Create exception.
 	 *
-	 * @param file Unreadable file.
+	 * @param file    Unreadable file.
 	 * @param message Error message.
 	 */
 	public UnreadableFileException(File file, String message) {

--- a/src/main/java/com/thebuzzmedia/exiftool/exceptions/UnsupportedFeatureException.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/exceptions/UnsupportedFeatureException.java
@@ -33,7 +33,7 @@ import static java.lang.String.format;
 public class UnsupportedFeatureException extends AbstractExifException {
 
 	/**
-	 * Exif Version (this version do not support feature).
+	 * Exif Version (this version does not support feature).
 	 */
 	private final Version version;
 
@@ -45,7 +45,7 @@ public class UnsupportedFeatureException extends AbstractExifException {
 	/**
 	 * Create exception.
 	 *
-	 * @param path ExifTool path.
+	 * @param path    ExifTool path.
 	 * @param version Exif Version.
 	 */
 	public UnsupportedFeatureException(String path, Version version) {

--- a/src/main/java/com/thebuzzmedia/exiftool/exceptions/UnwritableFileException.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/exceptions/UnwritableFileException.java
@@ -22,8 +22,10 @@ import java.io.File;
 /**
  * Exception thrown when a file cannot be written.
  * A file cannot be written because:
- * - It does not exist.
- * - It is corrupted and cannot be updated.
+ * <ul>
+ *   <li>It does not exist.</li>
+ *   <li>It is corrupted and cannot be updated.</li>
+ * </ul>
  */
 public class UnwritableFileException extends AbstractExifException {
 
@@ -35,7 +37,7 @@ public class UnwritableFileException extends AbstractExifException {
 	/**
 	 * Create exception.
 	 *
-	 * @param file Unwritable file.
+	 * @param file    Unwritable file.
 	 * @param message Error message.
 	 */
 	public UnwritableFileException(File file, String message) {

--- a/src/main/java/com/thebuzzmedia/exiftool/logs/DefaultLogger.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/logs/DefaultLogger.java
@@ -27,8 +27,8 @@ import static com.thebuzzmedia.exiftool.logs.LogUtils.fromSlf4jStyle;
  * <br>
  *
  * This logger will only log to the standard output.
- *
- * Log level will be detected using `exiftool.debug` system property.
+ * <p>
+ * Log level will be detected using {@code exiftool.debug} system property.
  * This system property can be set on startup with:
  * <ul>
  *   <li>{@code -Dexiftool.debug=true}</li>

--- a/src/main/java/com/thebuzzmedia/exiftool/logs/Logger.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/logs/Logger.java
@@ -38,7 +38,7 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param p1 Message parameter.
+	 * @param p1      Message parameter.
 	 */
 	void trace(String message, Object p1);
 
@@ -48,8 +48,8 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param p1 First message parameter.
-	 * @param p2 Second message parameter.
+	 * @param p1      First message parameter.
+	 * @param p2      Second message parameter.
 	 */
 	void trace(String message, Object p1, Object p2);
 
@@ -68,7 +68,7 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param p1 First message parameter.
+	 * @param p1      First message parameter.
 	 */
 	void info(String message, Object p1);
 
@@ -78,8 +78,8 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param p1 First message parameter.
-	 * @param p2 Second message parameter.
+	 * @param p1      First message parameter.
+	 * @param p2      Second message parameter.
 	 */
 	void info(String message, Object p1, Object p2);
 
@@ -98,7 +98,7 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param p1 Optional message parameter.
+	 * @param p1      Optional message parameter.
 	 */
 	void debug(String message, Object p1);
 
@@ -108,8 +108,8 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param p1 Optional (first) message parameter.
-	 * @param p2 Optional (second) message parameter.
+	 * @param p1      Optional (first) message parameter.
+	 * @param p2      Optional (second) message parameter.
 	 */
 	void debug(String message, Object p1, Object p2);
 
@@ -128,7 +128,7 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param ex The exception to log.
+	 * @param ex      The exception to log.
 	 */
 	void warn(String message, Throwable ex);
 
@@ -138,7 +138,7 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param p1 First message parameter.
+	 * @param p1      First message parameter.
 	 */
 	void warn(String message, Object p1);
 
@@ -148,8 +148,8 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param p1 First message parameter.
-	 * @param p2 Second message parameter.
+	 * @param p1      First message parameter.
+	 * @param p2      Second message parameter.
 	 */
 	void warn(String message, Object p1, Object p2);
 
@@ -168,7 +168,7 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param p1 First message parameter.
+	 * @param p1      First message parameter.
 	 */
 	void error(String message, Object p1);
 
@@ -178,8 +178,8 @@ public interface Logger {
 	 * is enabled.
 	 *
 	 * @param message Message to display.
-	 * @param p1 First message parameter.
-	 * @param p2 Second message parameter.
+	 * @param p1      First message parameter.
+	 * @param p2      Second message parameter.
 	 */
 	void error(String message, Object p1, Object p2);
 
@@ -187,7 +187,7 @@ public interface Logger {
 	 * Log exception stack trace as error Level.
 	 *
 	 * @param message Error message.
-	 * @param ex Thrown exception.
+	 * @param ex      Thrown exception.
 	 */
 	void error(String message, Throwable ex);
 

--- a/src/main/java/com/thebuzzmedia/exiftool/logs/LoggerLog4j.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/logs/LoggerLog4j.java
@@ -34,7 +34,7 @@ class LoggerLog4j implements Logger {
 
 	/**
 	 * Create logger.
-	 * This constructor should be called by {@link com.thebuzzmedia.exiftool.logs.LoggerFactory} only.
+	 * This constructor should be only called by {@link com.thebuzzmedia.exiftool.logs.LoggerFactory}.
 	 *
 	 * @param name Logger name.
 	 */

--- a/src/main/java/com/thebuzzmedia/exiftool/logs/LoggerLog4j2.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/logs/LoggerLog4j2.java
@@ -32,7 +32,7 @@ class LoggerLog4j2 implements Logger {
 
 	/**
 	 * Create logger.
-	 * This constructor should be called by {@link LoggerFactory} only.
+	 * This constructor should only be called by {@link LoggerFactory}.
 	 *
 	 * @param name Logger name.
 	 */

--- a/src/main/java/com/thebuzzmedia/exiftool/logs/LoggerProvider.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/logs/LoggerProvider.java
@@ -19,7 +19,7 @@ package com.thebuzzmedia.exiftool.logs;
 
 /**
  * A provider for {@link Logger} instance, that can be used with the Service Provider
- * Interface (see {@link java.util.ServiceLoader}.
+ * Interface (see {@link java.util.ServiceLoader}).
  */
 public interface LoggerProvider {
 

--- a/src/main/java/com/thebuzzmedia/exiftool/logs/LoggerSlf4j.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/logs/LoggerSlf4j.java
@@ -30,7 +30,7 @@ class LoggerSlf4j implements Logger {
 
 	/**
 	 * Create logger.
-	 * This constructor should be called by {@link com.thebuzzmedia.exiftool.logs.LoggerFactory} only.
+	 * This constructor should only be called by {@link com.thebuzzmedia.exiftool.logs.LoggerFactory}.
 	 *
 	 * @param name Logger name.
 	 */

--- a/src/main/java/com/thebuzzmedia/exiftool/process/CommandExecutor.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/process/CommandExecutor.java
@@ -26,8 +26,8 @@ public interface CommandExecutor {
 
 	/**
 	 * Execute command and build the result.
-	 *
-	 * **NOTE:** Execution is synchronous.
+	 * <p>
+	 * <strong>NOTE:</strong> Execution is synchronous.
 	 *
 	 * @param command Command input.
 	 * @return Result of execution.
@@ -37,7 +37,8 @@ public interface CommandExecutor {
 
 	/**
 	 * Execute command and build the result.
-	 * **NOTE:** Execution is synchronous.
+	 * <p>
+	 * <strong>NOTE:</strong> Execution is synchronous.
 	 *
 	 * @param command Command.
 	 * @param handler Custom output handler.
@@ -49,8 +50,10 @@ public interface CommandExecutor {
 	/**
 	 * Start command line and return associated process.
 	 * This process will be used to:
-	 * - Read output.
-	 * - Write arguments.
+	 * <ul>
+	 *   <li>Read output.</li>
+	 *   <li>Write arguments.</li>
+	 * </ul>
 	 *
 	 * @param command Command.
 	 * @return Process.

--- a/src/main/java/com/thebuzzmedia/exiftool/process/CommandProcess.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/process/CommandProcess.java
@@ -72,7 +72,7 @@ public interface CommandProcess extends AutoCloseable {
 	void write(String input, String... others) throws IOException;
 
 	/**
-	 * Write set of inputs to the current process.
+	 * Write a set of inputs to the current process.
 	 *
 	 * @param inputs Collection of inputs.
 	 * @throws java.io.IOException If an error occurred during operation.

--- a/src/main/java/com/thebuzzmedia/exiftool/process/OutputHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/process/OutputHandler.java
@@ -24,7 +24,7 @@ import com.thebuzzmedia.exiftool.commons.io.StreamVisitor;
  *
  * <br>
  *
- * Each line is give to the {@link #readLine(String)} method.
+ * Each line is given to the {@link #readLine(String)} method.
  * This method should return:
  * <ul>
  *   <li>

--- a/src/main/java/com/thebuzzmedia/exiftool/process/command/CommandBuilder.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/process/command/CommandBuilder.java
@@ -51,7 +51,7 @@ public class CommandBuilder {
 	 * Get new builder.
 	 *
 	 * @param executable Executable value.
-	 * @param nbArgs The expected number of arguments.
+	 * @param nbArgs     The expected number of arguments.
 	 * @return The new builder.
 	 * @throws NullPointerException If executable is null.
 	 * @throws IllegalArgumentException If executable is empty or blank.
@@ -85,7 +85,7 @@ public class CommandBuilder {
 	/**
 	 * Add new argument to the command line.
 	 *
-	 * @param arg First argument.
+	 * @param arg  First argument.
 	 * @param args Next optional arguments.
 	 * @return The builder.
 	 * @throws NullPointerException If one of the arguments is {@code null}.

--- a/src/main/java/com/thebuzzmedia/exiftool/process/command/CommandBuilder.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/process/command/CommandBuilder.java
@@ -94,10 +94,8 @@ public class CommandBuilder {
 	public CommandBuilder addArgument(String arg, String... args) {
 		add(arg);
 
-		if (args.length > 0) {
-			for (String a : args) {
-				add(a);
-			}
+		for (String a : args) {
+			add(a);
 		}
 
 		return this;

--- a/src/main/java/com/thebuzzmedia/exiftool/process/command/DefaultCommand.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/process/command/DefaultCommand.java
@@ -48,7 +48,7 @@ public final class DefaultCommand implements Command {
 	 * Create command line.
 	 *
 	 * @param executable Executable value.
-	 * @param arguments List of optional arguments.
+	 * @param arguments  List of optional arguments.
 	 */
 	public DefaultCommand(String executable, List<String> arguments) {
 		List<String> args = new ArrayList<>(size(arguments) + 1);

--- a/src/main/java/com/thebuzzmedia/exiftool/process/executor/CompositeHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/process/executor/CompositeHandler.java
@@ -28,15 +28,15 @@ import static java.util.Collections.unmodifiableList;
 /**
  * Composite handler.
  *
- * <p />
+ * <p>
  *
- * Run each internal handler and return false if one of them returns
- * false during line processing.
- *
+ * Run each internal handler and return {@code false} if one of them returns
+ * {@code false} during line processing.
+ * <p>
  * This class should only be used internally (to compose handlers during
  * command execution).
  *
- * <p />
+ * <p>
  *
  * <strong>Note:</strong> this class is thread safe if (and only if)
  * internal handlers are thread safe.

--- a/src/main/java/com/thebuzzmedia/exiftool/process/executor/DefaultCommandProcess.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/process/executor/DefaultCommandProcess.java
@@ -39,7 +39,7 @@ import static java.util.Objects.requireNonNull;
  *
  * <br>
  *
- * This implementation used instance of {@link InputStream} to handle
+ * This implementation uses instance of {@link InputStream} to handle
  * read operation and instance of {@link OutputStream} to handle write
  * operation. These streams may come from instance of {@link Process} for instance.
  *
@@ -78,8 +78,8 @@ public class DefaultCommandProcess implements CommandProcess {
 
 	/**
 	 * Create process.
-	 * @param is Input stream.
-	 * @param os Output stream.
+	 * @param is  Input stream.
+	 * @param os  Output stream.
 	 * @param err Error stream.
 	 */
 	public DefaultCommandProcess(InputStream is, OutputStream os, InputStream err) {

--- a/src/main/java/com/thebuzzmedia/exiftool/process/executor/DefaultCommandResult.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/process/executor/DefaultCommandResult.java
@@ -53,7 +53,7 @@ public final class DefaultCommandResult implements CommandResult {
 	 * Create new result.
 	 *
 	 * @param exitStatus Exit status.
-	 * @param output Standard output.
+	 * @param output     Standard output.
 	 */
 	public DefaultCommandResult(int exitStatus, String output) {
 		this.exitStatus = exitStatus;

--- a/src/main/java/com/thebuzzmedia/exiftool/process/executor/ResultHandler.java
+++ b/src/main/java/com/thebuzzmedia/exiftool/process/executor/ResultHandler.java
@@ -21,11 +21,11 @@ import com.thebuzzmedia.exiftool.Constants;
 import com.thebuzzmedia.exiftool.process.OutputHandler;
 
 /**
- * Simple command handler that just read output line by line
- * and append each one in a {@link StringBuilder} instance.
- * When current line is null, handler will return false.
+ * Simple command handler that just reads output line by line
+ * and appends each one in a {@link StringBuilder} instance.
+ * When current line is null, handler will return {@code false}.
  *
- * <p />
+ * <p>
  *
  * <strong>Note:</strong> that this handler is not thread safe and should be
  * synchronized if needed.


### PR DESCRIPTION
A bunch of cleanups, mostly Javadoc changes to fix grammar and formatting. Plus updated the readme to use the newer multithreading example and indicate only Java 8 and up is supported.

Also makes ExifToolBuilder use Java 8 functional interfaces instead of its own custom class, since as far as i can tell Java 8 is now required and it shouldn't break compatibility since they were private.

The changes are split in a couple of commits.